### PR TITLE
fix for escaped and grouping parentheses in like/regex operations

### DIFF
--- a/grammar/grammar.jjt
+++ b/grammar/grammar.jjt
@@ -109,6 +109,10 @@ SKIP :
   "\t"
 }
 
+TOKEN : { < ESCAPED_OPEN_PARENTHESES : "\\(" > }
+TOKEN : { < ESCAPED_CLOSE_PARENTHESES : "\\)" > }
+TOKEN : { < ESCAPED_LOCAL_RESOLUTION : "\\$" > }
+TOKEN : { < ESCAPED_LINK : "\\@" > }
 TOKEN : { < OPEN_PARENTHESES : "(" > }
 TOKEN : { < CLOSE_PARENTHESES : ")" > }
 TOKEN : { < OPEN_BRACKET : "[" > }
@@ -116,6 +120,7 @@ TOKEN : { < CLOSE_BRACKET : "]" > }
 TOKEN [IGNORE_CASE]: { < TIMESTAMP: "at" | "on" | "during" | "in" > }
 TOKEN [IGNORE_CASE]: { < WHERE: "where" > }
 TOKEN [IGNORE_CASE]: { < RESERVED_IDENTIFIER: "$id$" > }
+
 
 TOKEN [IGNORE_CASE]:
 {
@@ -193,7 +198,7 @@ TOKEN :
 |
   < NON_ALPHANUMERIC_AND_ALPHANUMERIC: (<NON_ALPHANUMERIC>|<ALPHANUMERIC>)+ >
 |
-  < #NON_ALPHANUMERIC: ~[",", "_","a"-"z","A"-"Z", "\n", "\t", "\r", " ", "(", ")", "[", "]", "="] >
+  < #NON_ALPHANUMERIC: ~[",", "_","a"-"z","A"-"Z", "\n", "\t", "\r", " ", "(", ")", "[", "]", "=", "\\"] >
 |
   < #LETTER: ["_","a"-"z","A"-"Z"] >
 |
@@ -252,7 +257,9 @@ void ConjunctionExpression() : {}
 
 void UnaryExpression() : {}
 {
-   (<OPEN_PARENTHESES>) DisjunctionExpression() (<CLOSE_PARENTHESES>) | RelationalExpression()
+   <OPEN_PARENTHESES> DisjunctionExpression() <CLOSE_PARENTHESES>
+ |
+   RelationalExpression()
 }
 
 void RelationalExpression() #Expression :
@@ -304,6 +311,7 @@ KeyTokenSymbol Key() :
 ValueTokenSymbol UnaryValue() :
 {
   FunctionValueSymbol function;
+  Token escape = null;
   Token key;
   Token word;
   String value = "";
@@ -316,8 +324,10 @@ ValueTokenSymbol UnaryValue() :
   (function=ValueFunction())
   { return function; }
 |
-  ( LOOKAHEAD(2) (word=<SIGNED_INTEGER> | word=<SIGNED_DECIMAL> | word=<NUMERIC> | word=<ALPHANUMERIC> | word=<NON_ALPHANUMERIC_AND_ALPHANUMERIC>  | word=<PERIOD_SEPARATED_STRING>) { value += (value.equals("")) ? word.image : " " + word.image; })+
+  (LOOKAHEAD(2) (escape=<ESCAPED_LINK> | escape=<ESCAPED_LOCAL_RESOLUTION>))? ( LOOKAHEAD(2) (word=<SIGNED_INTEGER> | word=<SIGNED_DECIMAL> | word=<NUMERIC> | word=<ALPHANUMERIC> | word=<NON_ALPHANUMERIC_AND_ALPHANUMERIC>  | word=<PERIOD_SEPARATED_STRING> | word=<ESCAPED_LOCAL_RESOLUTION> | word=<ESCAPED_LINK>) { value += (value.equals("")) ? word.image : " " + word.image; })+
   {
+    value = escape != null ? escape.image + value : value;
+
     if(value.charAt(0) == '$') {
         String var = value.substring(1);
         try {
@@ -359,24 +369,28 @@ ValueTokenSymbol RegexValue() :
 {
   Token word;
   String value = "";
-
 }
 {
-    <OPEN_PARENTHESES> (LOOKAHEAD(4) (word=<SIGNED_INTEGER> | word=<SIGNED_DECIMAL> | word=<NUMERIC> | word=<ALPHANUMERIC> | word=<NON_ALPHANUMERIC_AND_ALPHANUMERIC>  | word=<PERIOD_SEPARATED_STRING>  | word="_" | word="=")
-    {
-        if (value.equals("") |
-            value.endsWith("(") | word.image.equals(")") |
-            value.endsWith("=") | word.image.equals("=") |
-            value.endsWith("_") | word.image.equals("_")) {
-            value += word.image;
-        }
-        else {
-            value += " " + word.image;
-        }
-    })+ <CLOSE_PARENTHESES>
-    { return new ValueSymbol(transformValue("(" + value + ")")); }
+    (word=<QUOTED_STRING>)
+    { return new ValueSymbol(transformValue(word.image.replace("\\\"", "\""))); }
   |
-    (LOOKAHEAD(3) (word=<SIGNED_INTEGER> | word=<SIGNED_DECIMAL> | word=<NUMERIC> | word=<ALPHANUMERIC> | word=<NON_ALPHANUMERIC_AND_ALPHANUMERIC>  | word=<PERIOD_SEPARATED_STRING>  | word="_" | word="=")
+    value=RegexBaseValue()
+    { return new ValueSymbol(transformValue(value)); }
+}
+
+String RegexBaseValue() :
+{
+  Token word;
+  String base = "";
+  String baseOp = "";
+  String value = "";
+}
+{
+    (LOOKAHEAD(3) <OPEN_PARENTHESES> base=RegexBaseValue() <CLOSE_PARENTHESES> (LOOKAHEAD(3)baseOp=RegexBaseValue())?
+    {  value += "(" + base + ")" + baseOp; })+
+    {  return value; }
+  |
+    (LOOKAHEAD(2) (word=<SIGNED_INTEGER> | word=<SIGNED_DECIMAL> | word=<NUMERIC> | word=<ALPHANUMERIC> | word=<NON_ALPHANUMERIC_AND_ALPHANUMERIC>  | word=<PERIOD_SEPARATED_STRING> | word=<UNARY_OPERATOR> | word="_" | word = "," | word=<OPEN_BRACKET> | word=<CLOSE_BRACKET> | word=<ESCAPED_OPEN_PARENTHESES> | word=<ESCAPED_CLOSE_PARENTHESES>)
     {
         if (value.equals("") |
             value.endsWith("(") | word.image.equals(")") |
@@ -388,15 +402,13 @@ ValueTokenSymbol RegexValue() :
             value += " " + word.image;
         }
     })+
-    { return new ValueSymbol(transformValue(value)); }
-  |
-    (word=<QUOTED_STRING>)
-    { return new ValueSymbol(transformValue(word.image.replace("\\\"", "\""))); }
+    { return value; }
 }
 
 ValueTokenSymbol BinaryValue() :
 {
   FunctionValueSymbol function;
+  Token escape = null;
   Token key;
   Token word;
   String value = "";
@@ -409,9 +421,10 @@ ValueTokenSymbol BinaryValue() :
   (function=ValueFunction())
   { return function; }
 |
-  (word=<SIGNED_INTEGER> | word=<SIGNED_DECIMAL> | word=<NUMERIC> | word=<ALPHANUMERIC> | word=<NON_ALPHANUMERIC_AND_ALPHANUMERIC>  | word=<PERIOD_SEPARATED_STRING>)
+  (escape=<ESCAPED_LINK> | escape=<ESCAPED_LOCAL_RESOLUTION>)? (word=<SIGNED_INTEGER> | word=<SIGNED_DECIMAL> | word=<NUMERIC> | word=<ALPHANUMERIC> | word=<NON_ALPHANUMERIC_AND_ALPHANUMERIC>  | word=<PERIOD_SEPARATED_STRING>)
   {
-    value = word.image;
+    value = escape != null ? escape.image + word.image : word.image;
+
     if(value.charAt(0) == '$') {
         String var = value.substring(1);
         try {

--- a/src/main/java/com/cinchapi/ccl/generated/Grammar.java
+++ b/src/main/java/com/cinchapi/ccl/generated/Grammar.java
@@ -110,18 +110,18 @@ public class Grammar/*@bgen(jjtree)*/implements GrammarTreeConstants, GrammarCon
           jj_la1[2] = jj_gen;
           ;
         }
-        jj_consume_token(48);
+        jj_consume_token(52);
       } else {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case PAGE:
         case SIZE:{
           Page();
-          jj_consume_token(48);
+          jj_consume_token(52);
           break;
           }
         case ORDER:{
           Order();
-          jj_consume_token(48);
+          jj_consume_token(52);
           break;
           }
         case NUMERIC:
@@ -130,7 +130,7 @@ public class Grammar/*@bgen(jjtree)*/implements GrammarTreeConstants, GrammarCon
         case ALPHANUMERIC:
         case PERIOD_SEPARATED_STRING:{
           Function();
-          jj_consume_token(48);
+          jj_consume_token(52);
           break;
           }
         default:
@@ -552,22 +552,43 @@ if (jjtc000) {
 }
 
   final public ValueTokenSymbol UnaryValue() throws ParseException {FunctionValueSymbol function;
+  Token escape = null;
   Token key;
   Token word;
   String value = "";
   List<String> records = Lists.newArrayList();
   ASTStart ccl;
-    if (jj_2_5(2)) {
+    if (jj_2_6(2)) {
       function = ValueFunction();
 {if ("" != null) return function;}
     } else {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+      case ESCAPED_LOCAL_RESOLUTION:
+      case ESCAPED_LINK:
       case NUMERIC:
       case SIGNED_INTEGER:
       case SIGNED_DECIMAL:
       case ALPHANUMERIC:
       case PERIOD_SEPARATED_STRING:
       case NON_ALPHANUMERIC_AND_ALPHANUMERIC:{
+        if (jj_2_4(2)) {
+          switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+          case ESCAPED_LINK:{
+            escape = jj_consume_token(ESCAPED_LINK);
+            break;
+            }
+          case ESCAPED_LOCAL_RESOLUTION:{
+            escape = jj_consume_token(ESCAPED_LOCAL_RESOLUTION);
+            break;
+            }
+          default:
+            jj_la1[18] = jj_gen;
+            jj_consume_token(-1);
+            throw new ParseException();
+          }
+        } else {
+          ;
+        }
         label_3:
         while (true) {
           switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -595,253 +616,28 @@ if (jjtc000) {
             word = jj_consume_token(PERIOD_SEPARATED_STRING);
             break;
             }
+          case ESCAPED_LOCAL_RESOLUTION:{
+            word = jj_consume_token(ESCAPED_LOCAL_RESOLUTION);
+            break;
+            }
+          case ESCAPED_LINK:{
+            word = jj_consume_token(ESCAPED_LINK);
+            break;
+            }
           default:
-            jj_la1[18] = jj_gen;
+            jj_la1[19] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
 value += (value.equals("")) ? word.image : " " + word.image;
-          if (jj_2_4(2)) {
+          if (jj_2_5(2)) {
             ;
           } else {
             break label_3;
           }
         }
-if(value.charAt(0) == '$') {
-        String var = value.substring(1);
-        try {
-            value = Iterables.getOnlyElement(data.get(var)).toString();
-        }
-        catch (IllegalArgumentException e) {
-            String err = "Unable to resolve variable {} because multiple values exist locally: {}";
-            {if (true) throw new SyntaxException(AnyStrings.format(err, value, data.get(var)));}
-        }
-        catch (NoSuchElementException e) {
-            String err = "Unable to resolve variable {} because no values exist locally";
-            {if (true) throw new SyntaxException(AnyStrings.format(err, value));}
-        }
-    }
-    else if(value.length() > 2 && value.charAt(0) == '\\'
-            && value.charAt(1) == '$') {
-        value = value.substring(1);
-    }
-    else {
-        value = value.replace("\\@", "@");
-    }
-    {if ("" != null) return new ValueSymbol(transformValue(value));}
-        break;
-        }
-      case QUOTED_STRING:{
-        word = jj_consume_token(QUOTED_STRING);
-{if ("" != null) return new ValueSymbol(transformValue(word.image.replace("\\\"", "\"")));}
-        break;
-        }
-      default:
-        jj_la1[19] = jj_gen;
-        jj_consume_token(-1);
-        throw new ParseException();
-      }
-    }
-    throw new Error("Missing return statement in function");
-}
+value = escape != null ? escape.image + value : value;
 
-  final public ValueTokenSymbol LinksToValue() throws ParseException {Token word;
-    word = jj_consume_token(NUMERIC);
-{if ("" != null) return new ValueSymbol(transformValue(word.image));}
-    throw new Error("Missing return statement in function");
-}
-
-  final public ValueTokenSymbol RegexValue() throws ParseException {Token word;
-  String value = "";
-    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-    case OPEN_PARENTHESES:{
-      jj_consume_token(OPEN_PARENTHESES);
-      label_4:
-      while (true) {
-        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-        case SIGNED_INTEGER:{
-          word = jj_consume_token(SIGNED_INTEGER);
-          break;
-          }
-        case SIGNED_DECIMAL:{
-          word = jj_consume_token(SIGNED_DECIMAL);
-          break;
-          }
-        case NUMERIC:{
-          word = jj_consume_token(NUMERIC);
-          break;
-          }
-        case ALPHANUMERIC:{
-          word = jj_consume_token(ALPHANUMERIC);
-          break;
-          }
-        case NON_ALPHANUMERIC_AND_ALPHANUMERIC:{
-          word = jj_consume_token(NON_ALPHANUMERIC_AND_ALPHANUMERIC);
-          break;
-          }
-        case PERIOD_SEPARATED_STRING:{
-          word = jj_consume_token(PERIOD_SEPARATED_STRING);
-          break;
-          }
-        case 49:{
-          word = jj_consume_token(49);
-          break;
-          }
-        case 50:{
-          word = jj_consume_token(50);
-          break;
-          }
-        default:
-          jj_la1[20] = jj_gen;
-          jj_consume_token(-1);
-          throw new ParseException();
-        }
-if (value.equals("") |
-            value.endsWith("(") | word.image.equals(")") |
-            value.endsWith("=") | word.image.equals("=") |
-            value.endsWith("_") | word.image.equals("_")) {
-            value += word.image;
-        }
-        else {
-            value += " " + word.image;
-        }
-        if (jj_2_6(4)) {
-          ;
-        } else {
-          break label_4;
-        }
-      }
-      jj_consume_token(CLOSE_PARENTHESES);
-{if ("" != null) return new ValueSymbol(transformValue("(" + value + ")"));}
-      break;
-      }
-    case NUMERIC:
-    case SIGNED_INTEGER:
-    case SIGNED_DECIMAL:
-    case ALPHANUMERIC:
-    case PERIOD_SEPARATED_STRING:
-    case NON_ALPHANUMERIC_AND_ALPHANUMERIC:
-    case 49:
-    case 50:{
-      label_5:
-      while (true) {
-        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-        case SIGNED_INTEGER:{
-          word = jj_consume_token(SIGNED_INTEGER);
-          break;
-          }
-        case SIGNED_DECIMAL:{
-          word = jj_consume_token(SIGNED_DECIMAL);
-          break;
-          }
-        case NUMERIC:{
-          word = jj_consume_token(NUMERIC);
-          break;
-          }
-        case ALPHANUMERIC:{
-          word = jj_consume_token(ALPHANUMERIC);
-          break;
-          }
-        case NON_ALPHANUMERIC_AND_ALPHANUMERIC:{
-          word = jj_consume_token(NON_ALPHANUMERIC_AND_ALPHANUMERIC);
-          break;
-          }
-        case PERIOD_SEPARATED_STRING:{
-          word = jj_consume_token(PERIOD_SEPARATED_STRING);
-          break;
-          }
-        case 49:{
-          word = jj_consume_token(49);
-          break;
-          }
-        case 50:{
-          word = jj_consume_token(50);
-          break;
-          }
-        default:
-          jj_la1[21] = jj_gen;
-          jj_consume_token(-1);
-          throw new ParseException();
-        }
-if (value.equals("") |
-            value.endsWith("(") | word.image.equals(")") |
-            value.endsWith("=") | word.image.equals("=") |
-            value.endsWith("_") | word.image.equals("_")) {
-            value += word.image;
-        }
-        else {
-            value += " " + word.image;
-        }
-        if (jj_2_7(3)) {
-          ;
-        } else {
-          break label_5;
-        }
-      }
-{if ("" != null) return new ValueSymbol(transformValue(value));}
-      break;
-      }
-    case QUOTED_STRING:{
-      word = jj_consume_token(QUOTED_STRING);
-{if ("" != null) return new ValueSymbol(transformValue(word.image.replace("\\\"", "\"")));}
-      break;
-      }
-    default:
-      jj_la1[22] = jj_gen;
-      jj_consume_token(-1);
-      throw new ParseException();
-    }
-    throw new Error("Missing return statement in function");
-}
-
-  final public ValueTokenSymbol BinaryValue() throws ParseException {FunctionValueSymbol function;
-  Token key;
-  Token word;
-  String value = "";
-  List<String> records = Lists.newArrayList();
-  ASTStart ccl;
-    if (jj_2_8(2)) {
-      function = ValueFunction();
-{if ("" != null) return function;}
-    } else {
-      switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-      case NUMERIC:
-      case SIGNED_INTEGER:
-      case SIGNED_DECIMAL:
-      case ALPHANUMERIC:
-      case PERIOD_SEPARATED_STRING:
-      case NON_ALPHANUMERIC_AND_ALPHANUMERIC:{
-        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-        case SIGNED_INTEGER:{
-          word = jj_consume_token(SIGNED_INTEGER);
-          break;
-          }
-        case SIGNED_DECIMAL:{
-          word = jj_consume_token(SIGNED_DECIMAL);
-          break;
-          }
-        case NUMERIC:{
-          word = jj_consume_token(NUMERIC);
-          break;
-          }
-        case ALPHANUMERIC:{
-          word = jj_consume_token(ALPHANUMERIC);
-          break;
-          }
-        case NON_ALPHANUMERIC_AND_ALPHANUMERIC:{
-          word = jj_consume_token(NON_ALPHANUMERIC_AND_ALPHANUMERIC);
-          break;
-          }
-        case PERIOD_SEPARATED_STRING:{
-          word = jj_consume_token(PERIOD_SEPARATED_STRING);
-          break;
-          }
-        default:
-          jj_la1[23] = jj_gen;
-          jj_consume_token(-1);
-          throw new ParseException();
-        }
-value = word.image;
     if(value.charAt(0) == '$') {
         String var = value.substring(1);
         try {
@@ -872,7 +668,285 @@ value = word.image;
         break;
         }
       default:
-        jj_la1[24] = jj_gen;
+        jj_la1[20] = jj_gen;
+        jj_consume_token(-1);
+        throw new ParseException();
+      }
+    }
+    throw new Error("Missing return statement in function");
+}
+
+  final public ValueTokenSymbol LinksToValue() throws ParseException {Token word;
+    word = jj_consume_token(NUMERIC);
+{if ("" != null) return new ValueSymbol(transformValue(word.image));}
+    throw new Error("Missing return statement in function");
+}
+
+  final public ValueTokenSymbol RegexValue() throws ParseException {Token word;
+  String value = "";
+    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+    case QUOTED_STRING:{
+      word = jj_consume_token(QUOTED_STRING);
+{if ("" != null) return new ValueSymbol(transformValue(word.image.replace("\\\"", "\"")));}
+      break;
+      }
+    case ESCAPED_OPEN_PARENTHESES:
+    case ESCAPED_CLOSE_PARENTHESES:
+    case OPEN_PARENTHESES:
+    case OPEN_BRACKET:
+    case CLOSE_BRACKET:
+    case UNARY_OPERATOR:
+    case NUMERIC:
+    case COMMA:
+    case SIGNED_INTEGER:
+    case SIGNED_DECIMAL:
+    case ALPHANUMERIC:
+    case PERIOD_SEPARATED_STRING:
+    case NON_ALPHANUMERIC_AND_ALPHANUMERIC:
+    case 53:{
+      value = RegexBaseValue();
+{if ("" != null) return new ValueSymbol(transformValue(value));}
+      break;
+      }
+    default:
+      jj_la1[21] = jj_gen;
+      jj_consume_token(-1);
+      throw new ParseException();
+    }
+    throw new Error("Missing return statement in function");
+}
+
+  final public String RegexBaseValue() throws ParseException {Token word;
+  String base = "";
+  String baseOp = "";
+  String value = "";
+    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+    case OPEN_PARENTHESES:{
+      label_4:
+      while (true) {
+        jj_consume_token(OPEN_PARENTHESES);
+        base = RegexBaseValue();
+        jj_consume_token(CLOSE_PARENTHESES);
+        if (jj_2_7(3)) {
+          baseOp = RegexBaseValue();
+        } else {
+          ;
+        }
+value += "(" + base + ")" + baseOp;
+        if (jj_2_8(3)) {
+          ;
+        } else {
+          break label_4;
+        }
+      }
+{if ("" != null) return value;}
+      break;
+      }
+    case ESCAPED_OPEN_PARENTHESES:
+    case ESCAPED_CLOSE_PARENTHESES:
+    case OPEN_BRACKET:
+    case CLOSE_BRACKET:
+    case UNARY_OPERATOR:
+    case NUMERIC:
+    case COMMA:
+    case SIGNED_INTEGER:
+    case SIGNED_DECIMAL:
+    case ALPHANUMERIC:
+    case PERIOD_SEPARATED_STRING:
+    case NON_ALPHANUMERIC_AND_ALPHANUMERIC:
+    case 53:{
+      label_5:
+      while (true) {
+        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+        case SIGNED_INTEGER:{
+          word = jj_consume_token(SIGNED_INTEGER);
+          break;
+          }
+        case SIGNED_DECIMAL:{
+          word = jj_consume_token(SIGNED_DECIMAL);
+          break;
+          }
+        case NUMERIC:{
+          word = jj_consume_token(NUMERIC);
+          break;
+          }
+        case ALPHANUMERIC:{
+          word = jj_consume_token(ALPHANUMERIC);
+          break;
+          }
+        case NON_ALPHANUMERIC_AND_ALPHANUMERIC:{
+          word = jj_consume_token(NON_ALPHANUMERIC_AND_ALPHANUMERIC);
+          break;
+          }
+        case PERIOD_SEPARATED_STRING:{
+          word = jj_consume_token(PERIOD_SEPARATED_STRING);
+          break;
+          }
+        case UNARY_OPERATOR:{
+          word = jj_consume_token(UNARY_OPERATOR);
+          break;
+          }
+        case 53:{
+          word = jj_consume_token(53);
+          break;
+          }
+        case COMMA:{
+          word = jj_consume_token(COMMA);
+          break;
+          }
+        case OPEN_BRACKET:{
+          word = jj_consume_token(OPEN_BRACKET);
+          break;
+          }
+        case CLOSE_BRACKET:{
+          word = jj_consume_token(CLOSE_BRACKET);
+          break;
+          }
+        case ESCAPED_OPEN_PARENTHESES:{
+          word = jj_consume_token(ESCAPED_OPEN_PARENTHESES);
+          break;
+          }
+        case ESCAPED_CLOSE_PARENTHESES:{
+          word = jj_consume_token(ESCAPED_CLOSE_PARENTHESES);
+          break;
+          }
+        default:
+          jj_la1[22] = jj_gen;
+          jj_consume_token(-1);
+          throw new ParseException();
+        }
+if (value.equals("") |
+            value.endsWith("(") | word.image.equals(")") |
+            value.endsWith("=") | word.image.equals("=") |
+            value.endsWith("_") | word.image.equals("_")) {
+            value += word.image;
+        }
+        else {
+            value += " " + word.image;
+        }
+        if (jj_2_9(2)) {
+          ;
+        } else {
+          break label_5;
+        }
+      }
+{if ("" != null) return value;}
+      break;
+      }
+    default:
+      jj_la1[23] = jj_gen;
+      jj_consume_token(-1);
+      throw new ParseException();
+    }
+    throw new Error("Missing return statement in function");
+}
+
+  final public ValueTokenSymbol BinaryValue() throws ParseException {FunctionValueSymbol function;
+  Token escape = null;
+  Token key;
+  Token word;
+  String value = "";
+  List<String> records = Lists.newArrayList();
+  ASTStart ccl;
+    if (jj_2_10(2)) {
+      function = ValueFunction();
+{if ("" != null) return function;}
+    } else {
+      switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+      case ESCAPED_LOCAL_RESOLUTION:
+      case ESCAPED_LINK:
+      case NUMERIC:
+      case SIGNED_INTEGER:
+      case SIGNED_DECIMAL:
+      case ALPHANUMERIC:
+      case PERIOD_SEPARATED_STRING:
+      case NON_ALPHANUMERIC_AND_ALPHANUMERIC:{
+        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+        case ESCAPED_LOCAL_RESOLUTION:
+        case ESCAPED_LINK:{
+          switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+          case ESCAPED_LINK:{
+            escape = jj_consume_token(ESCAPED_LINK);
+            break;
+            }
+          case ESCAPED_LOCAL_RESOLUTION:{
+            escape = jj_consume_token(ESCAPED_LOCAL_RESOLUTION);
+            break;
+            }
+          default:
+            jj_la1[24] = jj_gen;
+            jj_consume_token(-1);
+            throw new ParseException();
+          }
+          break;
+          }
+        default:
+          jj_la1[25] = jj_gen;
+          ;
+        }
+        switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+        case SIGNED_INTEGER:{
+          word = jj_consume_token(SIGNED_INTEGER);
+          break;
+          }
+        case SIGNED_DECIMAL:{
+          word = jj_consume_token(SIGNED_DECIMAL);
+          break;
+          }
+        case NUMERIC:{
+          word = jj_consume_token(NUMERIC);
+          break;
+          }
+        case ALPHANUMERIC:{
+          word = jj_consume_token(ALPHANUMERIC);
+          break;
+          }
+        case NON_ALPHANUMERIC_AND_ALPHANUMERIC:{
+          word = jj_consume_token(NON_ALPHANUMERIC_AND_ALPHANUMERIC);
+          break;
+          }
+        case PERIOD_SEPARATED_STRING:{
+          word = jj_consume_token(PERIOD_SEPARATED_STRING);
+          break;
+          }
+        default:
+          jj_la1[26] = jj_gen;
+          jj_consume_token(-1);
+          throw new ParseException();
+        }
+value = escape != null ? escape.image + word.image : word.image;
+
+    if(value.charAt(0) == '$') {
+        String var = value.substring(1);
+        try {
+            value = Iterables.getOnlyElement(data.get(var)).toString();
+        }
+        catch (IllegalArgumentException e) {
+            String err = "Unable to resolve variable {} because multiple values exist locally: {}";
+            {if (true) throw new SyntaxException(AnyStrings.format(err, value, data.get(var)));}
+        }
+        catch (NoSuchElementException e) {
+            String err = "Unable to resolve variable {} because no values exist locally";
+            {if (true) throw new SyntaxException(AnyStrings.format(err, value));}
+        }
+    }
+    else if(value.length() > 2 && value.charAt(0) == '\\'
+            && value.charAt(1) == '$') {
+        value = value.substring(1);
+    }
+    else {
+        value = value.replace("\\@", "@");
+    }
+    {if ("" != null) return new ValueSymbol(transformValue(value));}
+        break;
+        }
+      case QUOTED_STRING:{
+        word = jj_consume_token(QUOTED_STRING);
+{if ("" != null) return new ValueSymbol(transformValue(word.image.replace("\\\"", "\"")));}
+        break;
+        }
+      default:
+        jj_la1[27] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -905,7 +979,7 @@ value = word.image;
       break;
       }
     default:
-      jj_la1[25] = jj_gen;
+      jj_la1[28] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -928,7 +1002,7 @@ value = word.image;
       break;
       }
     default:
-      jj_la1[26] = jj_gen;
+      jj_la1[29] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -973,12 +1047,12 @@ value = word.image;
         break;
         }
       default:
-        jj_la1[27] = jj_gen;
+        jj_la1[30] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
 timestamp += (timestamp.equals("")) ? word.image : " " + word.image;
-      if (jj_2_9(2)) {
+      if (jj_2_11(2)) {
         ;
       } else {
         break label_6;
@@ -1003,7 +1077,7 @@ timestamp += (timestamp.equals("")) ? word.image : " " + word.image;
           break;
           }
         default:
-          jj_la1[28] = jj_gen;
+          jj_la1[31] = jj_gen;
           ;
         }
         break;
@@ -1016,13 +1090,13 @@ timestamp += (timestamp.equals("")) ? word.image : " " + word.image;
           break;
           }
         default:
-          jj_la1[29] = jj_gen;
+          jj_la1[32] = jj_gen;
           ;
         }
         break;
         }
       default:
-        jj_la1[30] = jj_gen;
+        jj_la1[33] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -1081,7 +1155,7 @@ order.add(orderComponent);
           break;
           }
         default:
-          jj_la1[31] = jj_gen;
+          jj_la1[34] = jj_gen;
           break label_7;
         }
         jj_consume_token(COMMA);
@@ -1136,13 +1210,13 @@ if (jjtc000) {
         break;
         }
       default:
-        jj_la1[32] = jj_gen;
+        jj_la1[35] = jj_gen;
         ;
       }
       break;
       }
     default:
-      jj_la1[33] = jj_gen;
+      jj_la1[36] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1152,7 +1226,7 @@ if (jjtc000) {
       break;
       }
     default:
-      jj_la1[34] = jj_gen;
+      jj_la1[37] = jj_gen;
       ;
     }
 if(direction != null) {
@@ -1189,7 +1263,7 @@ if(direction != null) {
       break;
       }
     default:
-      jj_la1[35] = jj_gen;
+      jj_la1[38] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1209,7 +1283,7 @@ if(direction != null) {
       break;
       }
     default:
-      jj_la1[36] = jj_gen;
+      jj_la1[39] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1221,7 +1295,7 @@ if(direction != null) {
     boolean jjtc000 = true;
     jjtree.openNodeScope(jjtn000);FunctionTokenSymbol function;
     try {
-      if (jj_2_10(2)) {
+      if (jj_2_12(2)) {
         function = KeyFunction();
       } else {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -1230,7 +1304,7 @@ if(direction != null) {
           break;
           }
         default:
-          jj_la1[37] = jj_gen;
+          jj_la1[40] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -1283,7 +1357,7 @@ if (jjtc000) {
       break;
       }
     default:
-      jj_la1[38] = jj_gen;
+      jj_la1[41] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1301,7 +1375,7 @@ if (jjtc000) {
   TimestampSymbol timestamp = null;
     function = jj_consume_token(ALPHANUMERIC);
     jj_consume_token(OPEN_PARENTHESES);
-    if (jj_2_11(3)) {
+    if (jj_2_13(3)) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case SIGNED_INTEGER:{
         key = jj_consume_token(SIGNED_INTEGER);
@@ -1320,7 +1394,7 @@ if (jjtc000) {
         break;
         }
       default:
-        jj_la1[39] = jj_gen;
+        jj_la1[42] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -1338,11 +1412,11 @@ if (jjtc000) {
         break;
         }
       default:
-        jj_la1[40] = jj_gen;
+        jj_la1[43] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
-    } else if (jj_2_12(3)) {
+    } else if (jj_2_14(3)) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case SIGNED_INTEGER:{
         key = jj_consume_token(SIGNED_INTEGER);
@@ -1361,7 +1435,7 @@ if (jjtc000) {
         break;
         }
       default:
-        jj_la1[41] = jj_gen;
+        jj_la1[44] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -1379,7 +1453,7 @@ if (jjtc000) {
           break;
           }
         default:
-          jj_la1[42] = jj_gen;
+          jj_la1[45] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -1392,7 +1466,7 @@ records.add(word.image);
             break;
             }
           default:
-            jj_la1[43] = jj_gen;
+            jj_la1[46] = jj_gen;
             break label_8;
           }
           jj_consume_token(COMMA);
@@ -1406,7 +1480,7 @@ records.add(word.image);
             break;
             }
           default:
-            jj_la1[44] = jj_gen;
+            jj_la1[47] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -1428,7 +1502,7 @@ records.add(word.image);
           break;
           }
         default:
-          jj_la1[45] = jj_gen;
+          jj_la1[48] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -1441,7 +1515,7 @@ records.add(word.image);
             break;
             }
           default:
-            jj_la1[46] = jj_gen;
+            jj_la1[49] = jj_gen;
             break label_9;
           }
           jj_consume_token(COMMA);
@@ -1455,7 +1529,7 @@ records.add(word.image);
             break;
             }
           default:
-            jj_la1[47] = jj_gen;
+            jj_la1[50] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -1469,7 +1543,7 @@ records.add(word.image);
         break;
         }
       default:
-        jj_la1[48] = jj_gen;
+        jj_la1[51] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -1497,7 +1571,7 @@ records.add(word.image);
           break;
           }
         default:
-          jj_la1[49] = jj_gen;
+          jj_la1[52] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -1519,14 +1593,14 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
           break;
           }
         default:
-          jj_la1[50] = jj_gen;
+          jj_la1[53] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
         break;
         }
       default:
-        jj_la1[51] = jj_gen;
+        jj_la1[54] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -1630,15 +1704,285 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
     finally { jj_save(11, xla); }
   }
 
-  private boolean jj_3R_39()
+  private boolean jj_2_13(int xla)
  {
-    if (jj_3R_51()) return true;
-    if (jj_3R_52()) return true;
-    if (jj_3R_52()) return true;
+    jj_la = xla; jj_lastpos = jj_scanpos = token;
+    try { return (!jj_3_13()); }
+    catch(LookaheadSuccess ls) { return true; }
+    finally { jj_save(12, xla); }
+  }
+
+  private boolean jj_2_14(int xla)
+ {
+    jj_la = xla; jj_lastpos = jj_scanpos = token;
+    try { return (!jj_3_14()); }
+    catch(LookaheadSuccess ls) { return true; }
+    finally { jj_save(13, xla); }
+  }
+
+  private boolean jj_3R_56()
+ {
+    if (jj_scan_token(QUOTED_STRING)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_49()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_56()) {
+    jj_scanpos = xsp;
+    if (jj_3R_57()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_46()
+ {
+    if (jj_scan_token(NUMERIC)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_59()
+ {
+    if (jj_scan_token(QUOTED_STRING)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_24()
+ {
+    if (jj_scan_token(ORDER)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_36()
+ {
+    if (jj_scan_token(SIZE)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_50()
+ {
+    if (jj_3R_28()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_47()
+ {
+    if (jj_3R_28()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_53()
+ {
+    if (jj_3R_28()) return true;
+    return false;
+  }
+
+  private boolean jj_3_4()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(6)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(5)) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_58()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3_4()) jj_scanpos = xsp;
+    if (jj_3_5()) return true;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3_5()) { jj_scanpos = xsp; break; }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_35()
+ {
+    if (jj_scan_token(PAGE)) return true;
+    return false;
+  }
+
+  private boolean jj_3_6()
+ {
+    if (jj_3R_16()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_52()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3_6()) {
+    jj_scanpos = xsp;
+    if (jj_3R_58()) {
+    jj_scanpos = xsp;
+    if (jj_3R_59()) return true;
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_32()
+ {
+    if (jj_3R_36()) return true;
+    return false;
+  }
+
+  private boolean jj_3_11()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(38)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(43)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(44)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(41)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(45)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(47)) return true;
+    }
+    }
+    }
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_31()
+ {
+    if (jj_3R_35()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_25()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_31()) {
+    jj_scanpos = xsp;
+    if (jj_3R_32()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_44()
+ {
+    if (jj_scan_token(PERIOD_SEPARATED_STRING)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_43()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(13)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(43)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(44)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(41)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(45)) return true;
+    }
+    }
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_28()
+ {
+    if (jj_scan_token(TIMESTAMP)) return true;
+    return false;
+  }
+
+  private boolean jj_3_3()
+ {
+    if (jj_3R_15()) return true;
     return false;
   }
 
   private boolean jj_3R_38()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3_3()) {
+    jj_scanpos = xsp;
+    if (jj_3R_43()) {
+    jj_scanpos = xsp;
+    if (jj_3R_44()) return true;
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_54()
+ {
+    if (jj_scan_token(BINARY_OPERATOR)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_21()
+ {
+    if (jj_scan_token(OPEN_BRACKET)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_42()
+ {
+    if (jj_3R_54()) return true;
+    if (jj_3R_55()) return true;
+    if (jj_3R_55()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_41()
+ {
+    if (jj_3R_51()) return true;
+    if (jj_3R_52()) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_53()) jj_scanpos = xsp;
+    return false;
+  }
+
+  private boolean jj_3R_51()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(16)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(18)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(19)) return true;
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_20()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(43)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(41)) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_40()
  {
     if (jj_3R_48()) return true;
     if (jj_3R_49()) return true;
@@ -1648,13 +1992,7 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
     return false;
   }
 
-  private boolean jj_3R_20()
- {
-    if (jj_scan_token(OPEN_BRACKET)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_37()
+  private boolean jj_3R_39()
  {
     if (jj_3R_45()) return true;
     if (jj_3R_46()) return true;
@@ -1664,25 +2002,18 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
     return false;
   }
 
-  private boolean jj_3R_36()
- {
-    if (jj_3R_42()) return true;
-    if (jj_3R_43()) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_44()) jj_scanpos = xsp;
-    return false;
-  }
-
   private boolean jj_3R_48()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(12)) {
+    if (jj_scan_token(27)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(14)) {
+    if (jj_scan_token(28)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(15)) return true;
+    if (jj_scan_token(29)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(30)) return true;
+    }
     }
     }
     return false;
@@ -1690,191 +2021,125 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
 
   private boolean jj_3R_19()
  {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(39)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(37)) return true;
-    }
+    if (jj_scan_token(COMMA)) return true;
+    if (jj_3R_28()) return true;
     return false;
   }
 
-  private boolean jj_3R_53()
- {
-    if (jj_scan_token(OPEN_PARENTHESES)) return true;
-    Token xsp;
-    if (jj_3_6()) return true;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3_6()) { jj_scanpos = xsp; break; }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_46()
+  private boolean jj_3_14()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_53()) {
+    if (jj_scan_token(43)) {
     jj_scanpos = xsp;
-    if (jj_3R_54()) {
+    if (jj_scan_token(44)) {
     jj_scanpos = xsp;
-    if (jj_3R_55()) return true;
+    if (jj_scan_token(45)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(46)) return true;
     }
+    }
+    }
+    if (jj_scan_token(COMMA)) return true;
+    xsp = jj_scanpos;
+    if (jj_3R_20()) {
+    jj_scanpos = xsp;
+    if (jj_3R_21()) return true;
     }
     return false;
   }
 
   private boolean jj_3R_14()
  {
-    if (jj_3R_24()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_27()
- {
-    if (jj_scan_token(CONJUNCTION)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_22()
- {
-    if (jj_scan_token(DISJUNCTION)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_34()
- {
-    if (jj_3R_35()) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_36()) {
-    jj_scanpos = xsp;
-    if (jj_3R_37()) {
-    jj_scanpos = xsp;
-    if (jj_3R_38()) {
-    jj_scanpos = xsp;
-    if (jj_3R_39()) return true;
-    }
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3_12()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(39)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(40)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(41)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(42)) return true;
-    }
-    }
-    }
-    if (jj_scan_token(COMMA)) return true;
-    xsp = jj_scanpos;
-    if (jj_3R_19()) {
-    jj_scanpos = xsp;
-    if (jj_3R_20()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_18()
- {
-    if (jj_scan_token(COMMA)) return true;
     if (jj_3R_25()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_45()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(23)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(24)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(25)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(26)) return true;
-    }
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_17()
- {
-    if (jj_scan_token(CLOSE_PARENTHESES)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_13()
- {
-    if (jj_3R_23()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_43()
- {
-    if (jj_scan_token(NUMERIC)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_42()
- {
-    if (jj_scan_token(LINKS_TO)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_12()
- {
-    if (jj_3R_24()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_26()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_30()) {
-    jj_scanpos = xsp;
-    if (jj_3R_31()) return true;
-    }
     return false;
   }
 
   private boolean jj_3R_30()
  {
-    if (jj_scan_token(OPEN_PARENTHESES)) return true;
-    if (jj_3R_10()) return true;
+    if (jj_scan_token(CONJUNCTION)) return true;
     return false;
   }
 
-  private boolean jj_3_11()
+  private boolean jj_3R_37()
+ {
+    if (jj_3R_38()) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_39()) {
+    jj_scanpos = xsp;
+    if (jj_3R_40()) {
+    jj_scanpos = xsp;
+    if (jj_3R_41()) {
+    jj_scanpos = xsp;
+    if (jj_3R_42()) return true;
+    }
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3_7()
+ {
+    if (jj_3R_17()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_23()
+ {
+    if (jj_scan_token(DISJUNCTION)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_18()
+ {
+    if (jj_scan_token(CLOSE_PARENTHESES)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_45()
+ {
+    if (jj_scan_token(LINKS_TO)) return true;
+    return false;
+  }
+
+  private boolean jj_3_13()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(39)) {
+    if (jj_scan_token(43)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(40)) {
+    if (jj_scan_token(44)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(41)) {
+    if (jj_scan_token(45)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(42)) return true;
+    if (jj_scan_token(46)) return true;
     }
     }
     }
     xsp = jj_scanpos;
-    if (jj_3R_17()) {
+    if (jj_3R_18()) {
     jj_scanpos = xsp;
-    if (jj_3R_18()) return true;
+    if (jj_3R_19()) return true;
     }
+    return false;
+  }
+
+  private boolean jj_3R_13()
+ {
+    if (jj_3R_24()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_12()
+ {
+    if (jj_3R_25()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_34()
+ {
+    if (jj_3R_37()) return true;
     return false;
   }
 
@@ -1885,49 +2150,44 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
     return false;
   }
 
-  private boolean jj_3R_57()
+  private boolean jj_3R_61()
  {
     if (jj_scan_token(QUOTED_STRING)) return true;
     return false;
   }
 
-  private boolean jj_3R_59()
+  private boolean jj_3R_29()
  {
-    if (jj_scan_token(QUOTED_STRING)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_33()) {
+    jj_scanpos = xsp;
+    if (jj_3R_34()) return true;
+    }
     return false;
   }
 
-  private boolean jj_3R_21()
+  private boolean jj_3R_33()
  {
-    if (jj_3R_26()) return true;
+    if (jj_scan_token(OPEN_PARENTHESES)) return true;
+    if (jj_3R_10()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_22()
+ {
+    if (jj_3R_29()) return true;
     Token xsp;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3R_27()) { jj_scanpos = xsp; break; }
+      if (jj_3R_30()) { jj_scanpos = xsp; break; }
     }
     return false;
   }
 
   private boolean jj_3R_11()
  {
-    if (jj_3R_23()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_23()
- {
-    if (jj_scan_token(ORDER)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_10()
- {
-    if (jj_3R_21()) return true;
-    Token xsp;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3R_22()) { jj_scanpos = xsp; break; }
-    }
+    if (jj_3R_24()) return true;
     return false;
   }
 
@@ -1935,15 +2195,15 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(39)) {
+    if (jj_scan_token(43)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(40)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(37)) {
+    if (jj_scan_token(44)) {
     jj_scanpos = xsp;
     if (jj_scan_token(41)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(42)) return true;
+    if (jj_scan_token(45)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(46)) return true;
     }
     }
     }
@@ -1953,72 +2213,55 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
     return false;
   }
 
-  private boolean jj_3R_47()
+  private boolean jj_3R_10()
  {
-    if (jj_3R_25()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_50()
- {
-    if (jj_3R_25()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_44()
- {
-    if (jj_3R_25()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_33()
- {
-    if (jj_scan_token(SIZE)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_31()
- {
-    if (jj_3R_34()) return true;
-    return false;
-  }
-
-  private boolean jj_3_4()
- {
+    if (jj_3R_22()) return true;
     Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(39)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(40)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(37)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(41)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(43)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(42)) return true;
-    }
-    }
-    }
-    }
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3R_23()) { jj_scanpos = xsp; break; }
     }
     return false;
   }
 
-  private boolean jj_3_10()
+  private boolean jj_3_12()
  {
     if (jj_3R_15()) return true;
     return false;
   }
 
-  private boolean jj_3R_56()
+  private boolean jj_3R_62()
  {
     Token xsp;
-    if (jj_3_4()) return true;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3_4()) { jj_scanpos = xsp; break; }
+    xsp = jj_scanpos;
+    if (jj_scan_token(6)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(5)) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_60()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_62()) jj_scanpos = xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(43)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(44)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(41)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(45)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(47)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(46)) return true;
+    }
+    }
+    }
+    }
     }
     return false;
   }
@@ -2027,7 +2270,7 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(8)) jj_scanpos = xsp;
+    if (jj_scan_token(12)) jj_scanpos = xsp;
     if (jj_3R_10()) return true;
     xsp = jj_scanpos;
     if (jj_3R_13()) jj_scanpos = xsp;
@@ -2037,78 +2280,23 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
     return false;
   }
 
-  private boolean jj_3R_58()
+  private boolean jj_3R_55()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(39)) {
+    if (jj_3_10()) {
     jj_scanpos = xsp;
-    if (jj_scan_token(40)) {
+    if (jj_3R_60()) {
     jj_scanpos = xsp;
-    if (jj_scan_token(37)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(41)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(43)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(42)) return true;
-    }
-    }
-    }
+    if (jj_3R_61()) return true;
     }
     }
     return false;
   }
 
-  private boolean jj_3R_49()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3_5()) {
-    jj_scanpos = xsp;
-    if (jj_3R_56()) {
-    jj_scanpos = xsp;
-    if (jj_3R_57()) return true;
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3_5()
+  private boolean jj_3_10()
  {
     if (jj_3R_16()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_32()
- {
-    if (jj_scan_token(PAGE)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_52()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3_8()) {
-    jj_scanpos = xsp;
-    if (jj_3R_58()) {
-    jj_scanpos = xsp;
-    if (jj_3R_59()) return true;
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3_8()
- {
-    if (jj_3R_16()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_29()
- {
-    if (jj_3R_33()) return true;
     return false;
   }
 
@@ -2116,13 +2304,42 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(8)) jj_scanpos = xsp;
+    if (jj_scan_token(12)) jj_scanpos = xsp;
     if (jj_3R_10()) return true;
     xsp = jj_scanpos;
     if (jj_3R_11()) jj_scanpos = xsp;
     xsp = jj_scanpos;
     if (jj_3R_12()) jj_scanpos = xsp;
-    if (jj_scan_token(48)) return true;
+    if (jj_scan_token(52)) return true;
+    return false;
+  }
+
+  private boolean jj_3_5()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(43)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(44)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(41)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(45)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(47)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(46)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(5)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(6)) return true;
+    }
+    }
+    }
+    }
+    }
+    }
+    }
     return false;
   }
 
@@ -2130,99 +2347,36 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(34)) {
+    if (jj_scan_token(43)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(39)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(40)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(37)) {
+    if (jj_scan_token(44)) {
     jj_scanpos = xsp;
     if (jj_scan_token(41)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(43)) return true;
-    }
-    }
-    }
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_28()
- {
-    if (jj_3R_32()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_41()
- {
-    if (jj_scan_token(PERIOD_SEPARATED_STRING)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_24()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_28()) {
+    if (jj_scan_token(45)) {
     jj_scanpos = xsp;
-    if (jj_3R_29()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_55()
- {
-    if (jj_scan_token(QUOTED_STRING)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_40()
- {
-    Token xsp;
-    xsp = jj_scanpos;
+    if (jj_scan_token(47)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(46)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(16)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(53)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(42)) {
+    jj_scanpos = xsp;
     if (jj_scan_token(9)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(39)) {
+    if (jj_scan_token(10)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(40)) {
+    if (jj_scan_token(3)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(37)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(41)) return true;
+    if (jj_scan_token(4)) return true;
     }
     }
     }
     }
-    return false;
-  }
-
-  private boolean jj_3_3()
- {
-    if (jj_3R_15()) return true;
-    return false;
-  }
-
-  private boolean jj_3_6()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(39)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(40)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(37)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(41)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(43)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(42)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(49)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(50)) return true;
+    }
     }
     }
     }
@@ -2233,69 +2387,50 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
     return false;
   }
 
-  private boolean jj_3R_25()
- {
-    if (jj_scan_token(TIMESTAMP)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_35()
+  private boolean jj_3R_27()
  {
     Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3_3()) {
-    jj_scanpos = xsp;
-    if (jj_3R_40()) {
-    jj_scanpos = xsp;
-    if (jj_3R_41()) return true;
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3_7()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(39)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(40)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(37)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(41)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(43)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(42)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(49)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(50)) return true;
-    }
-    }
-    }
-    }
-    }
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_54()
- {
-    Token xsp;
-    if (jj_3_7()) return true;
+    if (jj_3_9()) return true;
     while (true) {
       xsp = jj_scanpos;
-      if (jj_3_7()) { jj_scanpos = xsp; break; }
+      if (jj_3_9()) { jj_scanpos = xsp; break; }
     }
     return false;
   }
 
-  private boolean jj_3R_51()
+  private boolean jj_3_8()
  {
-    if (jj_scan_token(BINARY_OPERATOR)) return true;
+    if (jj_scan_token(OPEN_PARENTHESES)) return true;
+    if (jj_3R_17()) return true;
+    if (jj_scan_token(CLOSE_PARENTHESES)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_26()
+ {
+    Token xsp;
+    if (jj_3_8()) return true;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3_8()) { jj_scanpos = xsp; break; }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_17()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_26()) {
+    jj_scanpos = xsp;
+    if (jj_3R_27()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_57()
+ {
+    if (jj_3R_17()) return true;
     return false;
   }
 
@@ -2310,7 +2445,7 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
   private Token jj_scanpos, jj_lastpos;
   private int jj_la;
   private int jj_gen;
-  final private int[] jj_la1 = new int[52];
+  final private int[] jj_la1 = new int[55];
   static private int[] jj_la1_0;
   static private int[] jj_la1_1;
   static {
@@ -2318,12 +2453,12 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
 	   jj_la1_init_1();
 	}
 	private static void jj_la1_init_0() {
-	   jj_la1_0 = new int[] {0x100,0x40000000,0x30000000,0x70000000,0x100,0x40000000,0x30000000,0x70000000,0x800,0x400,0x208,0x80,0x80,0x80,0x80,0x7c0f000,0x200,0x200,0x0,0x0,0x0,0x0,0x8,0x0,0x0,0x7800000,0xd000,0x0,0x20000000,0x10000000,0x30000000,0x0,0x80000000,0xc200,0x80,0xc000,0x80000000,0x0,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x20,0x0,0x10,0x0,};
+	   jj_la1_0 = new int[] {0x1000,0x0,0x0,0x0,0x1000,0x0,0x0,0x0,0x8000,0x4000,0x2080,0x800,0x800,0x800,0x800,0x7c0f0000,0x2000,0x2000,0x60,0x60,0x60,0x10698,0x10618,0x10698,0x60,0x60,0x0,0x60,0x78000000,0xd0000,0x0,0x0,0x0,0x0,0x0,0x0,0xc2000,0x800,0xc0000,0x0,0x0,0x0,0x0,0x100,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200,0x0,0x100,0x0,};
 	}
 	private static void jj_la1_init_1() {
-	   jj_la1_1 = new int[] {0x0,0x0,0x0,0x7a0,0x0,0x0,0x0,0x7a0,0x0,0x0,0x7a0,0x0,0x0,0x0,0x0,0x0,0x3a0,0x7a0,0xfa0,0xfa4,0x60fa0,0x60fa0,0x60fa4,0xfa0,0xfa4,0x0,0x0,0xba4,0x0,0x0,0x0,0x40,0x1,0x7a0,0x0,0x0,0x1,0x200,0x7a0,0x780,0x40,0x780,0xa0,0x40,0xa0,0xa0,0x40,0xa0,0xa0,0x780,0x40,0x780,};
+	   jj_la1_1 = new int[] {0x0,0x4,0x3,0x7a07,0x0,0x4,0x3,0x7a07,0x0,0x0,0x7a00,0x0,0x0,0x0,0x0,0x0,0x3a00,0x7a00,0x0,0xfa00,0xfa40,0x20fe40,0x20fe00,0x20fe00,0x0,0x0,0xfa00,0xfa40,0x0,0x0,0xba40,0x2,0x1,0x3,0x400,0x18,0x7a00,0x0,0x0,0x18,0x2000,0x7a00,0x7800,0x400,0x7800,0xa00,0x400,0xa00,0xa00,0x400,0xa00,0xa00,0x7800,0x400,0x7800,};
 	}
-  final private JJCalls[] jj_2_rtns = new JJCalls[12];
+  final private JJCalls[] jj_2_rtns = new JJCalls[14];
   private boolean jj_rescan = false;
   private int jj_gc = 0;
 
@@ -2338,7 +2473,7 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 52; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 55; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -2354,7 +2489,7 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
 	 jj_ntk = -1;
 	 jjtree.reset();
 	 jj_gen = 0;
-	 for (int i = 0; i < 52; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 55; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -2365,7 +2500,7 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 52; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 55; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -2385,7 +2520,7 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
 	 jj_ntk = -1;
 	 jjtree.reset();
 	 jj_gen = 0;
-	 for (int i = 0; i < 52; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 55; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -2395,7 +2530,7 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 52; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 55; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -2406,7 +2541,7 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
 	 jj_ntk = -1;
 	 jjtree.reset();
 	 jj_gen = 0;
-	 for (int i = 0; i < 52; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 55; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -2532,12 +2667,12 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
   /** Generate ParseException. */
   public ParseException generateParseException() {
 	 jj_expentries.clear();
-	 boolean[] la1tokens = new boolean[51];
+	 boolean[] la1tokens = new boolean[54];
 	 if (jj_kind >= 0) {
 	   la1tokens[jj_kind] = true;
 	   jj_kind = -1;
 	 }
-	 for (int i = 0; i < 52; i++) {
+	 for (int i = 0; i < 55; i++) {
 	   if (jj_la1[i] == jj_gen) {
 		 for (int j = 0; j < 32; j++) {
 		   if ((jj_la1_0[i] & (1<<j)) != 0) {
@@ -2549,7 +2684,7 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
 		 }
 	   }
 	 }
-	 for (int i = 0; i < 51; i++) {
+	 for (int i = 0; i < 54; i++) {
 	   if (la1tokens[i]) {
 		 jj_expentry = new int[1];
 		 jj_expentry[0] = i;
@@ -2584,7 +2719,7 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
 
   private void jj_rescan_token() {
 	 jj_rescan = true;
-	 for (int i = 0; i < 12; i++) {
+	 for (int i = 0; i < 14; i++) {
 	   try {
 		 JJCalls p = jj_2_rtns[i];
 
@@ -2604,6 +2739,8 @@ ConditionTree tree = (ConditionTree) ccl.jjtAccept(visitor, null);
 			   case 9: jj_3_10(); break;
 			   case 10: jj_3_11(); break;
 			   case 11: jj_3_12(); break;
+			   case 12: jj_3_13(); break;
+			   case 13: jj_3_14(); break;
 			 }
 		   }
 		   p = p.next;

--- a/src/main/java/com/cinchapi/ccl/generated/GrammarConstants.java
+++ b/src/main/java/com/cinchapi/ccl/generated/GrammarConstants.java
@@ -11,95 +11,103 @@ public interface GrammarConstants {
   /** End of File. */
   int EOF = 0;
   /** RegularExpression Id. */
-  int OPEN_PARENTHESES = 3;
+  int ESCAPED_OPEN_PARENTHESES = 3;
   /** RegularExpression Id. */
-  int CLOSE_PARENTHESES = 4;
+  int ESCAPED_CLOSE_PARENTHESES = 4;
   /** RegularExpression Id. */
-  int OPEN_BRACKET = 5;
+  int ESCAPED_LOCAL_RESOLUTION = 5;
   /** RegularExpression Id. */
-  int CLOSE_BRACKET = 6;
+  int ESCAPED_LINK = 6;
   /** RegularExpression Id. */
-  int TIMESTAMP = 7;
+  int OPEN_PARENTHESES = 7;
   /** RegularExpression Id. */
-  int WHERE = 8;
+  int CLOSE_PARENTHESES = 8;
   /** RegularExpression Id. */
-  int RESERVED_IDENTIFIER = 9;
+  int OPEN_BRACKET = 9;
   /** RegularExpression Id. */
-  int CONJUNCTION = 10;
+  int CLOSE_BRACKET = 10;
   /** RegularExpression Id. */
-  int DISJUNCTION = 11;
+  int TIMESTAMP = 11;
   /** RegularExpression Id. */
-  int UNARY_OPERATOR = 12;
+  int WHERE = 12;
   /** RegularExpression Id. */
-  int BINARY_OPERATOR = 13;
+  int RESERVED_IDENTIFIER = 13;
   /** RegularExpression Id. */
-  int OPEN_ANGLE_BRACKET = 14;
+  int CONJUNCTION = 14;
   /** RegularExpression Id. */
-  int CLOSE_ANGLE_BRACKET = 15;
+  int DISJUNCTION = 15;
   /** RegularExpression Id. */
-  int EQUALS = 16;
+  int UNARY_OPERATOR = 16;
   /** RegularExpression Id. */
-  int NOT_EQUALS = 17;
+  int BINARY_OPERATOR = 17;
   /** RegularExpression Id. */
-  int GREATER_THAN = 18;
+  int OPEN_ANGLE_BRACKET = 18;
   /** RegularExpression Id. */
-  int GREATER_THAN_OR_EQUALS = 19;
+  int CLOSE_ANGLE_BRACKET = 19;
   /** RegularExpression Id. */
-  int LESS_THAN = 20;
+  int EQUALS = 20;
   /** RegularExpression Id. */
-  int LESS_THAN_OR_EQUALS = 21;
+  int NOT_EQUALS = 21;
   /** RegularExpression Id. */
-  int LINKS_TO = 22;
+  int GREATER_THAN = 22;
   /** RegularExpression Id. */
-  int REGEX = 23;
+  int GREATER_THAN_OR_EQUALS = 23;
   /** RegularExpression Id. */
-  int NOT_REGEX = 24;
+  int LESS_THAN = 24;
   /** RegularExpression Id. */
-  int LIKE = 25;
+  int LESS_THAN_OR_EQUALS = 25;
   /** RegularExpression Id. */
-  int NOT_LIKE = 26;
+  int LINKS_TO = 26;
   /** RegularExpression Id. */
-  int BETWEEN = 27;
+  int REGEX = 27;
   /** RegularExpression Id. */
-  int PAGE = 28;
+  int NOT_REGEX = 28;
   /** RegularExpression Id. */
-  int SIZE = 29;
+  int LIKE = 29;
   /** RegularExpression Id. */
-  int ORDER = 30;
+  int NOT_LIKE = 30;
   /** RegularExpression Id. */
-  int ASC = 31;
+  int BETWEEN = 31;
   /** RegularExpression Id. */
-  int DESC = 32;
+  int PAGE = 32;
   /** RegularExpression Id. */
-  int PIPE = 33;
+  int SIZE = 33;
   /** RegularExpression Id. */
-  int QUOTED_STRING = 34;
+  int ORDER = 34;
   /** RegularExpression Id. */
-  int DOUBLE_QUOTED_STRING = 35;
+  int ASC = 35;
   /** RegularExpression Id. */
-  int SINGLE_QUOTED_STRING = 36;
+  int DESC = 36;
   /** RegularExpression Id. */
-  int NUMERIC = 37;
+  int PIPE = 37;
   /** RegularExpression Id. */
-  int COMMA = 38;
+  int QUOTED_STRING = 38;
   /** RegularExpression Id. */
-  int SIGNED_INTEGER = 39;
+  int DOUBLE_QUOTED_STRING = 39;
   /** RegularExpression Id. */
-  int SIGNED_DECIMAL = 40;
+  int SINGLE_QUOTED_STRING = 40;
   /** RegularExpression Id. */
-  int ALPHANUMERIC = 41;
+  int NUMERIC = 41;
   /** RegularExpression Id. */
-  int PERIOD_SEPARATED_STRING = 42;
+  int COMMA = 42;
   /** RegularExpression Id. */
-  int NON_ALPHANUMERIC_AND_ALPHANUMERIC = 43;
+  int SIGNED_INTEGER = 43;
   /** RegularExpression Id. */
-  int NON_ALPHANUMERIC = 44;
+  int SIGNED_DECIMAL = 44;
   /** RegularExpression Id. */
-  int LETTER = 45;
+  int ALPHANUMERIC = 45;
   /** RegularExpression Id. */
-  int DIGIT = 46;
+  int PERIOD_SEPARATED_STRING = 46;
   /** RegularExpression Id. */
-  int PERIOD = 47;
+  int NON_ALPHANUMERIC_AND_ALPHANUMERIC = 47;
+  /** RegularExpression Id. */
+  int NON_ALPHANUMERIC = 48;
+  /** RegularExpression Id. */
+  int LETTER = 49;
+  /** RegularExpression Id. */
+  int DIGIT = 50;
+  /** RegularExpression Id. */
+  int PERIOD = 51;
 
   /** Lexical state. */
   int DEFAULT = 0;
@@ -109,6 +117,10 @@ public interface GrammarConstants {
     "<EOF>",
     "\" \"",
     "\"\\t\"",
+    "\"\\\\(\"",
+    "\"\\\\)\"",
+    "\"\\\\$\"",
+    "\"\\\\@\"",
     "\"(\"",
     "\")\"",
     "\"[\"",
@@ -156,7 +168,6 @@ public interface GrammarConstants {
     "\".\"",
     "\"\\n\"",
     "\"_\"",
-    "\"=\"",
   };
 
 }

--- a/src/main/java/com/cinchapi/ccl/generated/GrammarTokenManager.java
+++ b/src/main/java/com/cinchapi/ccl/generated/GrammarTokenManager.java
@@ -33,7 +33,6 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 
 /** Token Manager. */
-@SuppressWarnings("unused")
 public class GrammarTokenManager implements GrammarConstants {
 
   /** Debug output. */
@@ -53,74 +52,73 @@ private int jjMoveStringLiteralDfa0_0(){
          jjmatchedKind = 2;
          return jjMoveNfa_0(5, 0);
       case 10:
-         jjmatchedKind = 48;
+         jjmatchedKind = 52;
          return jjMoveNfa_0(5, 0);
       case 32:
          jjmatchedKind = 1;
          return jjMoveNfa_0(5, 0);
       case 36:
-         return jjMoveStringLiteralDfa1_0(0x200L);
+         return jjMoveStringLiteralDfa1_0(0x2000L);
       case 40:
-         jjmatchedKind = 3;
+         jjmatchedKind = 7;
          return jjMoveNfa_0(5, 0);
       case 41:
-         jjmatchedKind = 4;
+         jjmatchedKind = 8;
          return jjMoveNfa_0(5, 0);
       case 44:
-         jjmatchedKind = 38;
+         jjmatchedKind = 42;
          return jjMoveNfa_0(5, 0);
       case 60:
-         jjmatchedKind = 14;
-         return jjMoveNfa_0(5, 0);
-      case 61:
-         jjmatchedKind = 50;
+         jjmatchedKind = 18;
          return jjMoveNfa_0(5, 0);
       case 62:
-         jjmatchedKind = 15;
+         jjmatchedKind = 19;
          return jjMoveNfa_0(5, 0);
       case 65:
-         return jjMoveStringLiteralDfa1_0(0x80000000L);
+         return jjMoveStringLiteralDfa1_0(0x800000000L);
       case 68:
-         return jjMoveStringLiteralDfa1_0(0x100000000L);
+         return jjMoveStringLiteralDfa1_0(0x1000000000L);
       case 76:
-         return jjMoveStringLiteralDfa1_0(0x2000000L);
-      case 79:
-         return jjMoveStringLiteralDfa1_0(0x40000000L);
-      case 80:
-         return jjMoveStringLiteralDfa1_0(0x10000000L);
-      case 82:
-         return jjMoveStringLiteralDfa1_0(0x800000L);
-      case 83:
          return jjMoveStringLiteralDfa1_0(0x20000000L);
+      case 79:
+         return jjMoveStringLiteralDfa1_0(0x400000000L);
+      case 80:
+         return jjMoveStringLiteralDfa1_0(0x100000000L);
+      case 82:
+         return jjMoveStringLiteralDfa1_0(0x8000000L);
+      case 83:
+         return jjMoveStringLiteralDfa1_0(0x200000000L);
       case 87:
-         return jjMoveStringLiteralDfa1_0(0x100L);
+         return jjMoveStringLiteralDfa1_0(0x1000L);
       case 91:
-         jjmatchedKind = 5;
+         jjmatchedKind = 9;
          return jjMoveNfa_0(5, 0);
+      case 92:
+         return jjMoveStringLiteralDfa1_0(0x78L);
       case 93:
-         jjmatchedKind = 6;
+         jjmatchedKind = 10;
          return jjMoveNfa_0(5, 0);
       case 95:
-         jjmatchedKind = 49;
+         jjmatchedKind = 53;
          return jjMoveNfa_0(5, 0);
       case 97:
-         return jjMoveStringLiteralDfa1_0(0x80000000L);
+         return jjMoveStringLiteralDfa1_0(0x800000000L);
       case 100:
-         return jjMoveStringLiteralDfa1_0(0x100000000L);
+         return jjMoveStringLiteralDfa1_0(0x1000000000L);
       case 108:
-         return jjMoveStringLiteralDfa1_0(0x2000000L);
-      case 111:
-         return jjMoveStringLiteralDfa1_0(0x40000000L);
-      case 112:
-         return jjMoveStringLiteralDfa1_0(0x10000000L);
-      case 114:
-         return jjMoveStringLiteralDfa1_0(0x800000L);
-      case 115:
          return jjMoveStringLiteralDfa1_0(0x20000000L);
+      case 111:
+         return jjMoveStringLiteralDfa1_0(0x400000000L);
+      case 112:
+         return jjMoveStringLiteralDfa1_0(0x100000000L);
+      case 114:
+         return jjMoveStringLiteralDfa1_0(0x8000000L);
+      case 115:
+         return jjMoveStringLiteralDfa1_0(0x200000000L);
       case 119:
-         return jjMoveStringLiteralDfa1_0(0x100L);
+         return jjMoveStringLiteralDfa1_0(0x1000L);
       case 124:
-         jjmatchedKind = 33;
+         jjmatchedKind = 37;
          return jjMoveNfa_0(5, 0);
       default :
          return jjMoveNfa_0(5, 0);
@@ -133,30 +131,58 @@ private int jjMoveStringLiteralDfa1_0(long active0){
    }
    switch(curChar)
    {
+      case 36:
+         if ((active0 & 0x20L) != 0L)
+         {
+            jjmatchedKind = 5;
+            jjmatchedPos = 1;
+         }
+         break;
+      case 40:
+         if ((active0 & 0x8L) != 0L)
+         {
+            jjmatchedKind = 3;
+            jjmatchedPos = 1;
+         }
+         break;
+      case 41:
+         if ((active0 & 0x10L) != 0L)
+         {
+            jjmatchedKind = 4;
+            jjmatchedPos = 1;
+         }
+         break;
+      case 64:
+         if ((active0 & 0x40L) != 0L)
+         {
+            jjmatchedKind = 6;
+            jjmatchedPos = 1;
+         }
+         break;
       case 65:
-         return jjMoveStringLiteralDfa2_0(active0, 0x10000000L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x100000000L);
       case 69:
-         return jjMoveStringLiteralDfa2_0(active0, 0x100800000L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x1008000000L);
       case 72:
-         return jjMoveStringLiteralDfa2_0(active0, 0x100L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x1000L);
       case 73:
-         return jjMoveStringLiteralDfa2_0(active0, 0x22000200L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x220002000L);
       case 82:
-         return jjMoveStringLiteralDfa2_0(active0, 0x40000000L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x400000000L);
       case 83:
-         return jjMoveStringLiteralDfa2_0(active0, 0x80000000L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x800000000L);
       case 97:
-         return jjMoveStringLiteralDfa2_0(active0, 0x10000000L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x100000000L);
       case 101:
-         return jjMoveStringLiteralDfa2_0(active0, 0x100800000L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x1008000000L);
       case 104:
-         return jjMoveStringLiteralDfa2_0(active0, 0x100L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x1000L);
       case 105:
-         return jjMoveStringLiteralDfa2_0(active0, 0x22000200L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x220002000L);
       case 114:
-         return jjMoveStringLiteralDfa2_0(active0, 0x40000000L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x400000000L);
       case 115:
-         return jjMoveStringLiteralDfa2_0(active0, 0x80000000L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x800000000L);
       default :
          break;
    }
@@ -172,43 +198,43 @@ private int jjMoveStringLiteralDfa2_0(long old0, long active0){
    switch(curChar)
    {
       case 67:
-         if ((active0 & 0x80000000L) != 0L)
+         if ((active0 & 0x800000000L) != 0L)
          {
-            jjmatchedKind = 31;
+            jjmatchedKind = 35;
             jjmatchedPos = 2;
          }
          break;
       case 68:
-         return jjMoveStringLiteralDfa3_0(active0, 0x40000200L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x400002000L);
       case 69:
-         return jjMoveStringLiteralDfa3_0(active0, 0x100L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x1000L);
       case 71:
-         return jjMoveStringLiteralDfa3_0(active0, 0x10800000L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x108000000L);
       case 75:
-         return jjMoveStringLiteralDfa3_0(active0, 0x2000000L);
-      case 83:
-         return jjMoveStringLiteralDfa3_0(active0, 0x100000000L);
-      case 90:
          return jjMoveStringLiteralDfa3_0(active0, 0x20000000L);
+      case 83:
+         return jjMoveStringLiteralDfa3_0(active0, 0x1000000000L);
+      case 90:
+         return jjMoveStringLiteralDfa3_0(active0, 0x200000000L);
       case 99:
-         if ((active0 & 0x80000000L) != 0L)
+         if ((active0 & 0x800000000L) != 0L)
          {
-            jjmatchedKind = 31;
+            jjmatchedKind = 35;
             jjmatchedPos = 2;
          }
          break;
       case 100:
-         return jjMoveStringLiteralDfa3_0(active0, 0x40000200L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x400002000L);
       case 101:
-         return jjMoveStringLiteralDfa3_0(active0, 0x100L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x1000L);
       case 103:
-         return jjMoveStringLiteralDfa3_0(active0, 0x10800000L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x108000000L);
       case 107:
-         return jjMoveStringLiteralDfa3_0(active0, 0x2000000L);
-      case 115:
-         return jjMoveStringLiteralDfa3_0(active0, 0x100000000L);
-      case 122:
          return jjMoveStringLiteralDfa3_0(active0, 0x20000000L);
+      case 115:
+         return jjMoveStringLiteralDfa3_0(active0, 0x1000000000L);
+      case 122:
+         return jjMoveStringLiteralDfa3_0(active0, 0x200000000L);
       default :
          break;
    }
@@ -224,64 +250,64 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0){
    switch(curChar)
    {
       case 36:
-         if ((active0 & 0x200L) != 0L)
+         if ((active0 & 0x2000L) != 0L)
          {
-            jjmatchedKind = 9;
+            jjmatchedKind = 13;
             jjmatchedPos = 3;
          }
          break;
       case 67:
-         if ((active0 & 0x100000000L) != 0L)
+         if ((active0 & 0x1000000000L) != 0L)
          {
-            jjmatchedKind = 32;
+            jjmatchedKind = 36;
             jjmatchedPos = 3;
          }
          break;
       case 69:
-         if ((active0 & 0x2000000L) != 0L)
-         {
-            jjmatchedKind = 25;
-            jjmatchedPos = 3;
-         }
-         else if ((active0 & 0x10000000L) != 0L)
-         {
-            jjmatchedKind = 28;
-            jjmatchedPos = 3;
-         }
-         else if ((active0 & 0x20000000L) != 0L)
+         if ((active0 & 0x20000000L) != 0L)
          {
             jjmatchedKind = 29;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x40800000L);
-      case 82:
-         return jjMoveStringLiteralDfa4_0(active0, 0x100L);
-      case 99:
-         if ((active0 & 0x100000000L) != 0L)
+         else if ((active0 & 0x100000000L) != 0L)
          {
             jjmatchedKind = 32;
             jjmatchedPos = 3;
          }
+         else if ((active0 & 0x200000000L) != 0L)
+         {
+            jjmatchedKind = 33;
+            jjmatchedPos = 3;
+         }
+         return jjMoveStringLiteralDfa4_0(active0, 0x408000000L);
+      case 82:
+         return jjMoveStringLiteralDfa4_0(active0, 0x1000L);
+      case 99:
+         if ((active0 & 0x1000000000L) != 0L)
+         {
+            jjmatchedKind = 36;
+            jjmatchedPos = 3;
+         }
          break;
       case 101:
-         if ((active0 & 0x2000000L) != 0L)
-         {
-            jjmatchedKind = 25;
-            jjmatchedPos = 3;
-         }
-         else if ((active0 & 0x10000000L) != 0L)
-         {
-            jjmatchedKind = 28;
-            jjmatchedPos = 3;
-         }
-         else if ((active0 & 0x20000000L) != 0L)
+         if ((active0 & 0x20000000L) != 0L)
          {
             jjmatchedKind = 29;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x40800000L);
+         else if ((active0 & 0x100000000L) != 0L)
+         {
+            jjmatchedKind = 32;
+            jjmatchedPos = 3;
+         }
+         else if ((active0 & 0x200000000L) != 0L)
+         {
+            jjmatchedKind = 33;
+            jjmatchedPos = 3;
+         }
+         return jjMoveStringLiteralDfa4_0(active0, 0x408000000L);
       case 114:
-         return jjMoveStringLiteralDfa4_0(active0, 0x100L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x1000L);
       default :
          break;
    }
@@ -297,34 +323,34 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0){
    switch(curChar)
    {
       case 69:
-         if ((active0 & 0x100L) != 0L)
+         if ((active0 & 0x1000L) != 0L)
          {
-            jjmatchedKind = 8;
+            jjmatchedKind = 12;
             jjmatchedPos = 4;
          }
          break;
       case 82:
-         return jjMoveStringLiteralDfa5_0(active0, 0x40000000L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x400000000L);
       case 88:
-         if ((active0 & 0x800000L) != 0L)
+         if ((active0 & 0x8000000L) != 0L)
          {
-            jjmatchedKind = 23;
+            jjmatchedKind = 27;
             jjmatchedPos = 4;
          }
          break;
       case 101:
-         if ((active0 & 0x100L) != 0L)
+         if ((active0 & 0x1000L) != 0L)
          {
-            jjmatchedKind = 8;
+            jjmatchedKind = 12;
             jjmatchedPos = 4;
          }
          break;
       case 114:
-         return jjMoveStringLiteralDfa5_0(active0, 0x40000000L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x400000000L);
       case 120:
-         if ((active0 & 0x800000L) != 0L)
+         if ((active0 & 0x8000000L) != 0L)
          {
-            jjmatchedKind = 23;
+            jjmatchedKind = 27;
             jjmatchedPos = 4;
          }
          break;
@@ -343,7 +369,7 @@ private int jjMoveStringLiteralDfa5_0(long old0, long active0){
    switch(curChar)
    {
       case 32:
-         return jjMoveStringLiteralDfa6_0(active0, 0x40000000L);
+         return jjMoveStringLiteralDfa6_0(active0, 0x400000000L);
       default :
          break;
    }
@@ -359,9 +385,9 @@ private int jjMoveStringLiteralDfa6_0(long old0, long active0){
    switch(curChar)
    {
       case 66:
-         return jjMoveStringLiteralDfa7_0(active0, 0x40000000L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x400000000L);
       case 98:
-         return jjMoveStringLiteralDfa7_0(active0, 0x40000000L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x400000000L);
       default :
          break;
    }
@@ -377,16 +403,16 @@ private int jjMoveStringLiteralDfa7_0(long old0, long active0){
    switch(curChar)
    {
       case 89:
-         if ((active0 & 0x40000000L) != 0L)
+         if ((active0 & 0x400000000L) != 0L)
          {
-            jjmatchedKind = 30;
+            jjmatchedKind = 34;
             jjmatchedPos = 7;
          }
          break;
       case 121:
-         if ((active0 & 0x40000000L) != 0L)
+         if ((active0 & 0x400000000L) != 0L)
          {
-            jjmatchedKind = 30;
+            jjmatchedKind = 34;
             jjmatchedPos = 7;
          }
          break;
@@ -450,19 +476,19 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 5:
                   if ((0xdfffecfeffffd9ffL & l) != 0L)
                   {
-                     if (kind > 43)
-                        kind = 43;
+                     if (kind > 47)
+                        kind = 47;
                      { jjCheckNAddTwoStates(20, 21); }
                   }
                   else if (curChar == 61)
                   {
-                     if (kind > 12)
-                        kind = 12;
+                     if (kind > 16)
+                        kind = 16;
                   }
                   if ((0x3ff000000000000L & l) != 0L)
                   {
-                     if (kind > 41)
-                        kind = 41;
+                     if (kind > 45)
+                        kind = 45;
                      { jjCheckNAddStates(0, 4); }
                   }
                   else if ((0x280000000000L & l) != 0L)
@@ -481,13 +507,13 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAdd(13); }
                   else if (curChar == 38)
                   {
-                     if (kind > 10)
-                        kind = 10;
+                     if (kind > 14)
+                        kind = 14;
                   }
                   if ((0x3ff000000000000L & l) != 0L)
                   {
-                     if (kind > 37)
-                        kind = 37;
+                     if (kind > 41)
+                        kind = 41;
                      { jjCheckNAddStates(16, 21); }
                   }
                   else if (curChar == 45)
@@ -496,28 +522,28 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 8;
                   break;
                case 8:
-                  if (curChar == 38 && kind > 10)
-                     kind = 10;
+                  if (curChar == 38 && kind > 14)
+                     kind = 14;
                   break;
                case 9:
                   if (curChar == 38)
                      jjstateSet[jjnewStateCnt++] = 8;
                   break;
                case 10:
-                  if (curChar == 38 && kind > 10)
-                     kind = 10;
+                  if (curChar == 38 && kind > 14)
+                     kind = 14;
                   break;
                case 13:
-                  if (curChar == 61 && kind > 12)
-                     kind = 12;
+                  if (curChar == 61 && kind > 16)
+                     kind = 16;
                   break;
                case 14:
                   if (curChar == 61)
                      { jjCheckNAdd(13); }
                   break;
                case 15:
-                  if (curChar == 61 && kind > 12)
-                     kind = 12;
+                  if (curChar == 61 && kind > 16)
+                     kind = 16;
                   break;
                case 16:
                   if (curChar == 33)
@@ -528,8 +554,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAdd(13); }
                   break;
                case 18:
-                  if (curChar == 62 && kind > 22)
-                     kind = 22;
+                  if (curChar == 62 && kind > 26)
+                     kind = 26;
                   break;
                case 19:
                   if (curChar == 45)
@@ -538,15 +564,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 20:
                   if ((0xdfffecfeffffd9ffL & l) == 0L)
                      break;
-                  if (kind > 43)
-                     kind = 43;
+                  if (kind > 47)
+                     kind = 47;
                   { jjCheckNAddTwoStates(20, 21); }
                   break;
                case 21:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 43)
-                     kind = 43;
+                  if (kind > 47)
+                     kind = 47;
                   { jjCheckNAddTwoStates(20, 21); }
                   break;
                case 78:
@@ -554,8 +580,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddTwoStates(13, 79); }
                   break;
                case 79:
-                  if (curChar == 60 && kind > 13)
-                     kind = 13;
+                  if (curChar == 60 && kind > 17)
+                     kind = 17;
                   break;
                case 82:
                case 83:
@@ -577,8 +603,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(28, 30); }
                   break;
                case 93:
-                  if (curChar == 34 && kind > 34)
-                     kind = 34;
+                  if (curChar == 34 && kind > 38)
+                     kind = 38;
                   break;
                case 95:
                   { jjCheckNAddStates(31, 33); }
@@ -588,8 +614,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(31, 33); }
                   break;
                case 97:
-                  if (curChar == 34 && kind > 35)
-                     kind = 35;
+                  if (curChar == 34 && kind > 39)
+                     kind = 39;
                   break;
                case 100:
                case 101:
@@ -619,8 +645,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(46, 48); }
                   break;
                case 120:
-                  if (curChar == 39 && kind > 34)
-                     kind = 34;
+                  if (curChar == 39 && kind > 38)
+                     kind = 38;
                   break;
                case 122:
                   { jjCheckNAddStates(49, 51); }
@@ -630,28 +656,28 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(49, 51); }
                   break;
                case 124:
-                  if (curChar == 39 && kind > 36)
-                     kind = 36;
+                  if (curChar == 39 && kind > 40)
+                     kind = 40;
                   break;
                case 125:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 37)
-                     kind = 37;
+                  if (kind > 41)
+                     kind = 41;
                   { jjCheckNAddStates(16, 21); }
                   break;
                case 126:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 37)
-                     kind = 37;
+                  if (kind > 41)
+                     kind = 41;
                   { jjCheckNAdd(126); }
                   break;
                case 127:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 39)
-                     kind = 39;
+                  if (kind > 43)
+                     kind = 43;
                   { jjCheckNAdd(127); }
                   break;
                case 128:
@@ -665,8 +691,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 130:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 40)
-                     kind = 40;
+                  if (kind > 44)
+                     kind = 44;
                   { jjCheckNAdd(130); }
                   break;
                case 131:
@@ -680,8 +706,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 133:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 42)
-                     kind = 42;
+                  if (kind > 46)
+                     kind = 46;
                   { jjCheckNAddTwoStates(133, 134); }
                   break;
                case 134:
@@ -703,15 +729,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 138:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 42)
-                     kind = 42;
+                  if (kind > 46)
+                     kind = 46;
                   { jjCheckNAddTwoStates(134, 138); }
                   break;
                case 139:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 42)
-                     kind = 42;
+                  if (kind > 46)
+                     kind = 46;
                   { jjCheckNAddTwoStates(134, 139); }
                   break;
                case 140:
@@ -721,27 +747,27 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 141:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 41)
-                     kind = 41;
+                  if (kind > 45)
+                     kind = 45;
                   { jjCheckNAddStates(0, 4); }
                   break;
                case 142:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 41)
-                     kind = 41;
+                  if (kind > 45)
+                     kind = 45;
                   { jjCheckNAdd(142); }
                   break;
                case 143:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 42)
-                     kind = 42;
+                  if (kind > 46)
+                     kind = 46;
                   { jjCheckNAddTwoStates(143, 134); }
                   break;
                case 201:
-                  if (curChar == 50 && kind > 22)
-                     kind = 22;
+                  if (curChar == 50 && kind > 26)
+                     kind = 26;
                   break;
                default : break;
             }
@@ -757,14 +783,14 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 5:
                   if ((0x7fffffe87fffffeL & l) != 0L)
                   {
-                     if (kind > 41)
-                        kind = 41;
+                     if (kind > 45)
+                        kind = 45;
                      { jjCheckNAddStates(0, 4); }
                   }
-                  else if ((0xf800000150000001L & l) != 0L)
+                  else if ((0xf800000140000001L & l) != 0L)
                   {
-                     if (kind > 43)
-                        kind = 43;
+                     if (kind > 47)
+                        kind = 47;
                      { jjCheckNAddTwoStates(20, 21); }
                   }
                   if ((0x100000001000L & l) != 0L)
@@ -791,8 +817,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 11;
                   break;
                case 0:
-                  if ((0x8000000080L & l) != 0L && kind > 7)
-                     kind = 7;
+                  if ((0x8000000080L & l) != 0L && kind > 11)
+                     kind = 11;
                   break;
                case 1:
                   if ((0x400000004000L & l) != 0L)
@@ -811,33 +837,33 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 3;
                   break;
                case 6:
-                  if ((0x400000004000L & l) != 0L && kind > 7)
-                     kind = 7;
+                  if ((0x400000004000L & l) != 0L && kind > 11)
+                     kind = 11;
                   break;
                case 7:
                   if ((0x20000000200L & l) != 0L)
                      { jjCheckNAdd(6); }
                   break;
                case 11:
-                  if (curChar == 124 && kind > 11)
-                     kind = 11;
+                  if (curChar == 124 && kind > 15)
+                     kind = 15;
                   break;
                case 12:
                   if (curChar == 124)
                      jjstateSet[jjnewStateCnt++] = 11;
                   break;
                case 20:
-                  if ((0xf800000150000001L & l) == 0L)
+                  if ((0xf800000140000001L & l) == 0L)
                      break;
-                  if (kind > 43)
-                     kind = 43;
+                  if (kind > 47)
+                     kind = 47;
                   { jjCheckNAddTwoStates(20, 21); }
                   break;
                case 21:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
-                  if (kind > 43)
-                     kind = 43;
+                  if (kind > 47)
+                     kind = 47;
                   { jjCheckNAddTwoStates(20, 21); }
                   break;
                case 22:
@@ -845,12 +871,12 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjAddStates(76, 77); }
                   break;
                case 23:
-                  if ((0x80000000800000L & l) != 0L && kind > 13)
-                     kind = 13;
+                  if ((0x80000000800000L & l) != 0L && kind > 17)
+                     kind = 17;
                   break;
                case 24:
-                  if ((0x400000004000L & l) != 0L && kind > 13)
-                     kind = 13;
+                  if ((0x400000004000L & l) != 0L && kind > 17)
+                     kind = 17;
                   break;
                case 25:
                   if ((0x2000000020L & l) != 0L)
@@ -877,8 +903,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjAddStates(74, 75); }
                   break;
                case 31:
-                  if ((0x8000000080000L & l) != 0L && kind > 12)
-                     kind = 12;
+                  if ((0x8000000080000L & l) != 0L && kind > 16)
+                     kind = 16;
                   break;
                case 32:
                case 50:
@@ -900,16 +926,16 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 34;
                   break;
                case 36:
-                  if ((0x2000000020000L & l) != 0L && kind > 12)
-                     kind = 12;
+                  if ((0x2000000020000L & l) != 0L && kind > 16)
+                     kind = 16;
                   break;
                case 37:
                   if ((0x8000000080L & l) != 0L)
                      { jjCheckNAddStates(70, 73); }
                   break;
                case 38:
-                  if ((0x400000004000L & l) != 0L && kind > 12)
-                     kind = 12;
+                  if ((0x400000004000L & l) != 0L && kind > 16)
+                     kind = 16;
                   break;
                case 39:
                case 176:
@@ -953,8 +979,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 47;
                   break;
                case 49:
-                  if ((0x10000000100000L & l) != 0L && kind > 12)
-                     kind = 12;
+                  if ((0x10000000100000L & l) != 0L && kind > 16)
+                     kind = 16;
                   break;
                case 51:
                   if ((0x200000002L & l) != 0L)
@@ -1033,8 +1059,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 68;
                   break;
                case 70:
-                  if ((0x2000000020L & l) != 0L && kind > 12)
-                     kind = 12;
+                  if ((0x2000000020L & l) != 0L && kind > 16)
+                     kind = 16;
                   break;
                case 71:
                case 200:
@@ -1046,12 +1072,12 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjAddStates(68, 69); }
                   break;
                case 73:
-                  if ((0x10000000100000L & l) != 0L && kind > 7)
-                     kind = 7;
+                  if ((0x10000000100000L & l) != 0L && kind > 11)
+                     kind = 11;
                   break;
                case 74:
-                  if ((0x1000000010L & l) != 0L && kind > 10)
-                     kind = 10;
+                  if ((0x1000000010L & l) != 0L && kind > 14)
+                     kind = 14;
                   break;
                case 75:
                   if ((0x400000004000L & l) != 0L)
@@ -1062,8 +1088,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddTwoStates(6, 77); }
                   break;
                case 77:
-                  if ((0x4000000040000L & l) != 0L && kind > 11)
-                     kind = 11;
+                  if ((0x4000000040000L & l) != 0L && kind > 15)
+                     kind = 15;
                   break;
                case 81:
                   if (curChar == 92)
@@ -1125,8 +1151,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(34, 36); }
                   break;
                case 102:
-                  if (curChar == 96 && kind > 34)
-                     kind = 34;
+                  if (curChar == 96 && kind > 38)
+                     kind = 38;
                   break;
                case 103:
                   if (curChar == 92)
@@ -1140,8 +1166,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(37, 39); }
                   break;
                case 106:
-                  if (curChar == 96 && kind > 36)
-                     kind = 36;
+                  if (curChar == 96 && kind > 40)
+                     kind = 40;
                   break;
                case 108:
                   if (curChar == 92)
@@ -1190,29 +1216,29 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 139:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
-                  if (kind > 42)
-                     kind = 42;
+                  if (kind > 46)
+                     kind = 46;
                   { jjCheckNAddTwoStates(134, 139); }
                   break;
                case 141:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
-                  if (kind > 41)
-                     kind = 41;
+                  if (kind > 45)
+                     kind = 45;
                   { jjCheckNAddStates(0, 4); }
                   break;
                case 142:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
-                  if (kind > 41)
-                     kind = 41;
+                  if (kind > 45)
+                     kind = 45;
                   { jjCheckNAdd(142); }
                   break;
                case 143:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
-                  if (kind > 42)
-                     kind = 42;
+                  if (kind > 46)
+                     kind = 46;
                   { jjCheckNAddTwoStates(143, 134); }
                   break;
                case 144:
@@ -1248,8 +1274,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 151;
                   break;
                case 153:
-                  if ((0x100000001000000L & l) != 0L && kind > 24)
-                     kind = 24;
+                  if ((0x100000001000000L & l) != 0L && kind > 28)
+                     kind = 28;
                   break;
                case 154:
                case 158:
@@ -1293,8 +1319,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 163;
                   break;
                case 165:
-                  if ((0x2000000020L & l) != 0L && kind > 26)
-                     kind = 26;
+                  if ((0x2000000020L & l) != 0L && kind > 30)
+                     kind = 30;
                   break;
                case 166:
                case 169:
@@ -1442,8 +1468,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 205;
                   break;
                case 207:
-                  if ((0x800000008000L & l) != 0L && kind > 22)
-                     kind = 22;
+                  if ((0x800000008000L & l) != 0L && kind > 26)
+                     kind = 26;
                   break;
                case 208:
                   if ((0x10000000100000L & l) != 0L)
@@ -1487,8 +1513,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 5:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
                   {
-                     if (kind > 43)
-                        kind = 43;
+                     if (kind > 47)
+                        kind = 47;
                      { jjCheckNAddTwoStates(20, 21); }
                   }
                   if (jjCanMove_1(hiByte, i1, i2, l1, l2))
@@ -1499,8 +1525,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 20:
                   if (!jjCanMove_0(hiByte, i1, i2, l1, l2))
                      break;
-                  if (kind > 43)
-                     kind = 43;
+                  if (kind > 47)
+                     kind = 47;
                   { jjCheckNAddTwoStates(20, 21); }
                   break;
                case 80:
@@ -1516,8 +1542,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(22, 24); }
                   break;
                case 84:
-                  if (jjCanMove_3(hiByte, i1, i2, l1, l2) && kind > 34)
-                     kind = 34;
+                  if (jjCanMove_3(hiByte, i1, i2, l1, l2) && kind > 38)
+                     kind = 38;
                   break;
                case 86:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
@@ -1528,8 +1554,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(25, 27); }
                   break;
                case 88:
-                  if (jjCanMove_3(hiByte, i1, i2, l1, l2) && kind > 35)
-                     kind = 35;
+                  if (jjCanMove_3(hiByte, i1, i2, l1, l2) && kind > 39)
+                     kind = 39;
                   break;
                case 91:
                case 92:
@@ -1564,8 +1590,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(40, 42); }
                   break;
                case 111:
-                  if (jjCanMove_6(hiByte, i1, i2, l1, l2) && kind > 34)
-                     kind = 34;
+                  if (jjCanMove_6(hiByte, i1, i2, l1, l2) && kind > 38)
+                     kind = 38;
                   break;
                case 113:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
@@ -1576,8 +1602,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(43, 45); }
                   break;
                case 115:
-                  if (jjCanMove_6(hiByte, i1, i2, l1, l2) && kind > 36)
-                     kind = 36;
+                  if (jjCanMove_6(hiByte, i1, i2, l1, l2) && kind > 40)
+                     kind = 40;
                   break;
                case 118:
                case 119:
@@ -1628,10 +1654,11 @@ private int jjMoveNfa_0(int startState, int curPos)
 
 /** Token literal values. */
 public static final String[] jjstrLiteralImages = {
-"", null, null, "\50", "\51", "\133", "\135", null, null, null, null, null, 
-null, null, "\74", "\76", null, null, null, null, null, null, null, null, null, null, 
-null, null, null, null, null, null, null, "\174", null, null, null, null, "\54", 
-null, null, null, null, null, null, null, null, null, "\12", "\137", "\75", };
+"", null, null, "\134\50", "\134\51", "\134\44", "\134\100", "\50", "\51", 
+"\133", "\135", null, null, null, null, null, null, null, "\74", "\76", null, null, 
+null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
+null, "\174", null, null, null, null, "\54", null, null, null, null, null, null, 
+null, null, null, "\12", "\137", };
 protected Token jjFillToken()
 {
    final Token t;
@@ -1928,10 +1955,10 @@ public static final String[] lexStateNames = {
 public static final int[] jjnewLexState = {
    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
-   -1, 
+   -1, -1, -1, -1, 
 };
 static final long[] jjtoToken = {
-   0x70ffff7c0fff9L, 
+   0x30ffff7c0ffff9L, 
 };
 static final long[] jjtoSkip = {
    0x6L, 


### PR DESCRIPTION
Added missing support for parentheses within regex/like operators which are required to be escaped
Added missing support for grouping with parentheses within regex/like operator
Modified to handle escaped links and escaped local resolution seperately to avoid conflict with escaped parenthesis
