### PR TITLE
feat: Add Compiler#parse(List<Symbol>) for symbol-based AST assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,11 @@ A new `Compiler#analyze(CommandTree)` returns `CommandAnalysis extends Statement
 * `rangeStart()` / `rangeEnd()` — for `audit`, `chronicle`, `diff`.
 * `referencedRecords()` — `Set<Long>` of record ids the command directly touches.
 
+##### Symbol-Based Parsing
+Added `Compiler#parse(List<Symbol>)` for callers that already hold structured `Symbol`s (e.g., decoded from a wire protocol or produced programmatically) and want to build a `ConditionTree` without going through CCL text. It is the inverse of `tokenize(AbstractSyntaxTree)` for condition input — feeding the result of `tokenize` back through `parse` reconstructs the original tree. Variable substitution remains a text-level concern; placeholders must be resolved before the symbols are constructed.
+
+The new method unblocks conditions whose keys collide with CCL command keywords (e.g., `select = 42`), which the lexer otherwise reserves as global tokens and cannot parse as a condition from text.
+
 ##### Other Grammar Updates
 * [GH-51](https://github.com/cinchapi/ccl/issues/51): Allow an optional `*` suffix on navigation key segments to mark them as transitive (e.g., `children*.name`, `a.b*.c.d*.e`, `children*`). Transitive segments instruct Concourse to follow links recursively until exhaustion, supporting the Transitive Navigation feature in [cinchapi/concourse#632](https://github.com/cinchapi/concourse/issues/632). A standalone transitive stop (e.g., `children*`) is also accepted as a navigation key and is equivalent to a single-stop path whose terminal stop is transitive. Added `NavigationKeyStop` to model each segment as a structured `(name, transitive)` pair, and `NavigationKeySymbol#stops()` to expose them; the existing `components()` method is unchanged.
 * [GH-52](https://github.com/cinchapi/ccl/issues/52): Added **scoped condition groups** via the `prefix.(...)` syntax. Tells the engine that all conditions inside the group must be satisfied by the **same** destination record reachable through the explicit navigation `prefix`, rather than being evaluated independently (which can produce false positives on multi-valued links). Supports [cinchapi/concourse#533](https://github.com/cinchapi/concourse/issues/533).

--- a/src/main/java/com/cinchapi/ccl/Compiler.java
+++ b/src/main/java/com/cinchapi/ccl/Compiler.java
@@ -863,12 +863,14 @@ public abstract class Compiler {
                         "Unexpected symbol in postfix notation: " + symbol);
             }
         }
-        if(stack.size() != 1 || !(stack.peek() instanceof ConditionTree)) {
+        if(stack.size() == 1 && stack.peek() instanceof ConditionTree) {
+            return (ConditionTree) stack.pop();
+        }
+        else {
             throw new SyntaxException(
                     "Symbols did not reduce to a single condition tree: "
                             + symbols);
         }
-        return (ConditionTree) stack.pop();
     }
 
     /**

--- a/src/main/java/com/cinchapi/ccl/Compiler.java
+++ b/src/main/java/com/cinchapi/ccl/Compiler.java
@@ -799,6 +799,79 @@ public abstract class Compiler {
     }
 
     /**
+     * Build the {@link ConditionTree} represented by {@code symbols},
+     * bypassing CCL text parsing.
+     * <p>
+     * Use this overload when callers already hold structured
+     * {@link Symbol Symbols} (for example, decoded from a wire protocol or
+     * produced programmatically) and want to skip the text round-trip. It
+     * acts as the inverse of {@link #tokenize(AbstractSyntaxTree)} for
+     * {@link ConditionTree} input: feeding the result of {@code tokenize}
+     * back through this method reconstructs the original tree.
+     * </p>
+     * <p>
+     * Variable substitution (e.g., {@code $name}) is a text-level concern
+     * and is not performed here; callers must resolve placeholders before
+     * constructing the {@link Symbol Symbols} they pass in.
+     * </p>
+     * <p>
+     * Only condition-level {@link Symbol Symbols} are accepted &mdash;
+     * {@link ExpressionSymbol}, {@link ConjunctionSymbol},
+     * {@link ParenthesisSymbol}, {@link ScopeSymbol}, and
+     * {@link ScopeEndSymbol}, plus the raw key/operator/value tokens that
+     * compose an expression. Top-level statement components such as
+     * {@link com.cinchapi.ccl.grammar.OrderSymbol OrderSymbol},
+     * {@link com.cinchapi.ccl.grammar.PageSymbol PageSymbol},
+     * {@link com.cinchapi.ccl.grammar.FunctionTokenSymbol
+     * FunctionTokenSymbol}, and command symbols are not part of the
+     * postfix-notation pipeline and are rejected.
+     * </p>
+     *
+     * @param symbols the {@link Symbol Symbols} to assemble
+     * @return the {@link ConditionTree} represented by {@code symbols}
+     * @throws SyntaxException if {@code symbols} contain a
+     *             non-condition {@link Symbol} or do not reduce to a
+     *             single tree
+     */
+    public final ConditionTree parse(List<Symbol> symbols) {
+        Queue<PostfixNotationSymbol> postfix = Parsing
+                .toPostfixNotation(symbols);
+        Deque<Object> stack = new ArrayDeque<>();
+        while (!postfix.isEmpty()) {
+            PostfixNotationSymbol symbol = postfix.poll();
+            if(symbol instanceof ExpressionSymbol) {
+                stack.push(new ExpressionTree((ExpressionSymbol) symbol));
+            }
+            else if(symbol instanceof ConjunctionSymbol) {
+                ConditionTree right = (ConditionTree) stack.pop();
+                ConditionTree left = (ConditionTree) stack.pop();
+                stack.push(symbol == ConjunctionSymbol.AND
+                        ? new AndTree(left, right)
+                        : new OrTree(left, right));
+            }
+            else if(symbol instanceof ScopeSymbol) {
+                stack.push(symbol);
+            }
+            else if(symbol == ScopeEndSymbol.INSTANCE) {
+                ConditionTree inner = (ConditionTree) stack.pop();
+                ScopeSymbol open = (ScopeSymbol) stack.pop();
+                stack.push(
+                        new ScopedConditionTree(open.prefix(), inner));
+            }
+            else {
+                throw new SyntaxException(
+                        "Unexpected symbol in postfix notation: " + symbol);
+            }
+        }
+        if(stack.size() != 1 || !(stack.peek() instanceof ConditionTree)) {
+            throw new SyntaxException(
+                    "Symbols did not reduce to a single condition tree: "
+                            + symbols);
+        }
+        return (ConditionTree) stack.pop();
+    }
+
+    /**
      * Traverse the {@code ast} in breadth-first order and break up its nodes
      * into distinct {@link Symbol symbols} (i.e. separate an
      * {@link ExpressionSymbol} into its distinct parts}.

--- a/src/main/java/com/cinchapi/ccl/Compiler.java
+++ b/src/main/java/com/cinchapi/ccl/Compiler.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.Set;
 import java.util.function.Function;
@@ -834,34 +835,47 @@ public abstract class Compiler {
      *             single tree
      */
     public final ConditionTree parse(List<Symbol> symbols) {
-        Queue<PostfixNotationSymbol> postfix = Parsing
-                .toPostfixNotation(symbols);
+        Queue<PostfixNotationSymbol> postfix;
+        try {
+            postfix = Parsing.toPostfixNotation(symbols);
+        }
+        catch (IllegalStateException | ClassCastException e) {
+            throw new SyntaxException(
+                    "Symbols are not a valid condition: " + symbols);
+        }
         Deque<Object> stack = new ArrayDeque<>();
-        while (!postfix.isEmpty()) {
-            PostfixNotationSymbol symbol = postfix.poll();
-            if(symbol instanceof ExpressionSymbol) {
-                stack.push(new ExpressionTree((ExpressionSymbol) symbol));
+        try {
+            while (!postfix.isEmpty()) {
+                PostfixNotationSymbol symbol = postfix.poll();
+                if(symbol instanceof ExpressionSymbol) {
+                    stack.push(new ExpressionTree((ExpressionSymbol) symbol));
+                }
+                else if(symbol instanceof ConjunctionSymbol) {
+                    ConditionTree right = (ConditionTree) stack.pop();
+                    ConditionTree left = (ConditionTree) stack.pop();
+                    stack.push(symbol == ConjunctionSymbol.AND
+                            ? new AndTree(left, right)
+                            : new OrTree(left, right));
+                }
+                else if(symbol instanceof ScopeSymbol) {
+                    stack.push(symbol);
+                }
+                else if(symbol == ScopeEndSymbol.INSTANCE) {
+                    ConditionTree inner = (ConditionTree) stack.pop();
+                    ScopeSymbol open = (ScopeSymbol) stack.pop();
+                    stack.push(new ScopedConditionTree(open.prefix(), inner));
+                }
+                else {
+                    throw new SyntaxException(
+                            "Unexpected symbol in postfix notation: "
+                                    + symbol);
+                }
             }
-            else if(symbol instanceof ConjunctionSymbol) {
-                ConditionTree right = (ConditionTree) stack.pop();
-                ConditionTree left = (ConditionTree) stack.pop();
-                stack.push(symbol == ConjunctionSymbol.AND
-                        ? new AndTree(left, right)
-                        : new OrTree(left, right));
-            }
-            else if(symbol instanceof ScopeSymbol) {
-                stack.push(symbol);
-            }
-            else if(symbol == ScopeEndSymbol.INSTANCE) {
-                ConditionTree inner = (ConditionTree) stack.pop();
-                ScopeSymbol open = (ScopeSymbol) stack.pop();
-                stack.push(
-                        new ScopedConditionTree(open.prefix(), inner));
-            }
-            else {
-                throw new SyntaxException(
-                        "Unexpected symbol in postfix notation: " + symbol);
-            }
+        }
+        catch (ClassCastException | NoSuchElementException e) {
+            throw new SyntaxException(
+                    "Symbols did not reduce to a single condition tree: "
+                            + symbols);
         }
         if(stack.size() == 1 && stack.peek() instanceof ConditionTree) {
             return (ConditionTree) stack.pop();

--- a/src/test/java/com/cinchapi/ccl/CompilerTest.java
+++ b/src/test/java/com/cinchapi/ccl/CompilerTest.java
@@ -28,6 +28,7 @@ import com.cinchapi.ccl.syntax.FunctionTree;
 import com.cinchapi.ccl.syntax.OrTree;
 import com.cinchapi.ccl.syntax.OrderTree;
 import com.cinchapi.ccl.syntax.PageTree;
+import com.cinchapi.ccl.syntax.ScopedConditionTree;
 import com.cinchapi.ccl.grammar.command.SelectSymbol;
 import com.cinchapi.ccl.grammar.command.NavigateSymbol;
 import com.cinchapi.ccl.syntax.CommandTree;
@@ -1624,10 +1625,37 @@ public abstract class CompilerTest {
                 .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
                 .value(42).build();
         Compiler compiler = createCompiler();
+        // The lexer reserves command keywords as global tokens, so the text
+        // path cannot parse a condition whose key collides with one. The
+        // symbols path bypasses the lexer and is the supported route.
+        try {
+            compiler.parse("select = 42");
+            Assert.fail(
+                    "Expected text parse of \"select = 42\" to fail "
+                            + "because \"select\" is a reserved keyword");
+        }
+        catch (Exception expected) {/* text path is structurally broken */}
         ConditionTree tree = compiler.parse(criteria.symbols());
         Assert.assertTrue(tree instanceof ExpressionTree);
         ExpressionSymbol root = (ExpressionSymbol) tree.root();
         Assert.assertEquals("select", root.raw().key());
+    }
+
+    @Test
+    public void testParseSymbolsRoundTripsScopedCondition() {
+        Compiler compiler = createCompiler();
+        AbstractSyntaxTree fromText = compiler
+                .parse("friends.(name = jeff and age > 30)");
+        ConditionTree fromSymbols = compiler
+                .parse(compiler.tokenize(fromText));
+        Assert.assertTrue(fromSymbols instanceof ScopedConditionTree);
+        Assert.assertEquals(fromText, fromSymbols);
+    }
+
+    @Test(expected = SyntaxException.class)
+    public void testParseSymbolsThrowsSyntaxExceptionForMalformedInput() {
+        Compiler compiler = createCompiler();
+        compiler.parse(Lists.newArrayList());
     }
 
 }

--- a/src/test/java/com/cinchapi/ccl/CompilerTest.java
+++ b/src/test/java/com/cinchapi/ccl/CompilerTest.java
@@ -21,9 +21,11 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import com.cinchapi.ccl.syntax.AndTree;
 import com.cinchapi.ccl.syntax.ConjunctionTree;
 import com.cinchapi.ccl.syntax.ExpressionTree;
 import com.cinchapi.ccl.syntax.FunctionTree;
+import com.cinchapi.ccl.syntax.OrTree;
 import com.cinchapi.ccl.syntax.OrderTree;
 import com.cinchapi.ccl.syntax.PageTree;
 import com.cinchapi.ccl.grammar.command.SelectSymbol;
@@ -1535,6 +1537,97 @@ public abstract class CompilerTest {
                             + key.getClass().getName(),
                     key instanceof KeyTokenSymbol);
         }
+    }
+
+    @Test
+    public void testParseSymbolsSingleExpression() {
+        Criteria criteria = Criteria.where().key("a")
+                .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
+                .value(1).build();
+        Compiler compiler = createCompiler();
+        ConditionTree tree = compiler.parse(criteria.symbols());
+        Assert.assertTrue(tree instanceof ExpressionTree);
+        Assert.assertEquals(compiler.parse("a = 1"), tree);
+    }
+
+    @Test
+    public void testParseSymbolsAnd() {
+        Criteria criteria = Criteria.where().key("a")
+                .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
+                .value(1).and().key("b")
+                .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
+                .value(2).build();
+        Compiler compiler = createCompiler();
+        ConditionTree tree = compiler.parse(criteria.symbols());
+        Assert.assertTrue(tree instanceof AndTree);
+        Assert.assertEquals(compiler.parse("a = 1 and b = 2"), tree);
+    }
+
+    @Test
+    public void testParseSymbolsOr() {
+        Criteria criteria = Criteria.where().key("a")
+                .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
+                .value(1).or().key("b")
+                .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
+                .value(2).build();
+        Compiler compiler = createCompiler();
+        ConditionTree tree = compiler.parse(criteria.symbols());
+        Assert.assertTrue(tree instanceof OrTree);
+        Assert.assertEquals(compiler.parse("a = 1 or b = 2"), tree);
+    }
+
+    @Test
+    public void testParseSymbolsHonorsPrecedence() {
+        Criteria criteria = Criteria.where().key("a")
+                .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
+                .value(1).or().key("b")
+                .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
+                .value(2).and().key("c")
+                .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
+                .value(3).build();
+        Compiler compiler = createCompiler();
+        ConditionTree tree = compiler.parse(criteria.symbols());
+        Assert.assertTrue(tree instanceof OrTree);
+        Assert.assertEquals(compiler.parse("a = 1 or b = 2 and c = 3"), tree);
+    }
+
+    @Test
+    public void testParseSymbolsRespectsParentheses() {
+        Criteria criteria = Criteria.where()
+                .group(Criteria.where().key("a")
+                        .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
+                        .value(1).or().key("b")
+                        .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
+                        .value(2).build())
+                .and().key("c")
+                .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
+                .value(3).build();
+        Compiler compiler = createCompiler();
+        ConditionTree tree = compiler.parse(criteria.symbols());
+        Assert.assertTrue(tree instanceof AndTree);
+        Assert.assertEquals(compiler.parse("(a = 1 or b = 2) and c = 3"),
+                tree);
+    }
+
+    @Test
+    public void testParseSymbolsRoundTripsThroughTokenize() {
+        Compiler compiler = createCompiler();
+        AbstractSyntaxTree fromText = compiler.parse(
+                "a = 1 and (b = 2 or c = 3) or d = 4");
+        ConditionTree fromSymbols = compiler.parse(compiler.tokenize(fromText));
+        Assert.assertEquals(fromText, fromSymbols);
+    }
+
+    @Test
+    public void testParseSymbolsAcceptsKeysCollidingWithCommandKeywords() {
+        Criteria criteria = Criteria.where().key("select")
+                .operator(com.cinchapi.concourse.thrift.Operator.EQUALS)
+                .value(42).build();
+        Compiler compiler = createCompiler();
+        ConditionTree tree = compiler.parse(criteria.symbols());
+        Assert.assertTrue(tree instanceof ExpressionTree);
+        ExpressionSymbol root = (ExpressionSymbol) tree.root();
+        Assert.assertEquals("select", root.raw().key());
     }
 
 }


### PR DESCRIPTION
## Summary

Adds `Compiler#parse(List<Symbol>)` &mdash; the symmetric inverse of `tokenize(AbstractSyntaxTree)`. Callers that already hold typed `Symbol`s (decoded from a wire protocol, produced programmatically, or anything else) can now produce a `ConditionTree` without round-tripping through CCL text.

The method walks `Parsing.toPostfixNotation(symbols)` and assembles `ExpressionTree` / `AndTree` / `OrTree` / `ScopedConditionTree` directly. Variable substitution (`$name`) stays a text-level concern; by the time you have `ValueSymbol`s, placeholders are already resolved.

## Why

CCL's lexer reserves command keywords (`SELECT`, `FIND`, `GET`, `AUDIT`, etc.) as global tokens and the `Key()` production at [grammar.jjt:545](grammar/grammar.jjt) does not accept them. So `select = 42` is structurally unparseable as a condition: the lexer emits `<SELECT> <UNARY_OPERATOR> <NUMERIC>`, the top-level `Statement()` rule tries `Command()` first (matches `<SELECT>`), `SelectCommand` fails on `= 42`, and there is no LOOKAHEAD to backtrack into `DisjunctionExpression`.

This affects any downstream consumer that builds conditions from typed symbols and then passes them to a parser via `.ccl()` text marshalling. Concourse hits it specifically when a `Criteria` is built with a key whose name collides with a CCL command keyword.

The structural fix isn't to patch the grammar &mdash; it's to give consumers a way to assemble a tree from typed symbols they already have, since text marshalling is the wrong shape for that input. CCL already exposes the inverse direction (`tokenize(AST) -> symbols`); this method closes the round-trip.

## API

```java
public final ConditionTree parse(List<Symbol> symbols);
```

- Returns `ConditionTree` rather than `AbstractSyntaxTree` &mdash; only `PostfixNotationSymbol` types (`ExpressionSymbol`, `ConjunctionSymbol`, `ScopeSymbol`, `ScopeEndSymbol`) flow through `toPostfixNotation`, so the symbols path is condition-only by construction. Top-level statement components (`OrderSymbol`, `PageSymbol`, command symbols) are not part of the postfix pipeline and are documented as out of scope.
- No `data` overload &mdash; variable substitution happens before symbol construction.
- No `compile` cousin &mdash; symbol streams have no statement separator (no `SemicolonSymbol`), so a list of symbols is always exactly one statement. A `compile(List<Symbol>)` returning a singleton list would be misleading API.

## Test plan

- [x] `testParseSymbolsSingleExpression` &mdash; trivial single expression
- [x] `testParseSymbolsAnd` / `testParseSymbolsOr` &mdash; binary conjunctions
- [x] `testParseSymbolsHonorsPrecedence` &mdash; AND binds tighter than OR through the postfix walker
- [x] `testParseSymbolsRespectsParentheses` &mdash; grouped sub-criteria
- [x] `testParseSymbolsRoundTripsThroughTokenize` &mdash; `parse(tokenize(parse(text))) == parse(text)`
- [x] `testParseSymbolsAcceptsKeysCollidingWithCommandKeywords` &mdash; pins the actual fix; demonstrates that `Criteria.where().key("select")` builds a tree without going near the text parser
- [x] Full CCL suite green: 953 tests, 0 failures
