### PR TITLE
feat: [GH-75] Modification-timestamp marker foo[t1~] for added-at-or-after binding

### DIFF
--- a/CCL_REFERENCE.md
+++ b/CCL_REFERENCE.md
@@ -483,6 +483,41 @@ bindings on navigation stops, scope prefixes, and transitive keys are
 not yet supported. Evaluating what a range read returns is a
 server-side concern and is outside the grammar.
 
+#### Modification marker (leaf keys)
+
+A leaf key can bind to the values whose **add** occurred at or after a
+timestamp, using a trailing `~` marker. The form `key[t~]` binds the key
+over the half-open window `[t, now)`: start-inclusive at `t`,
+end-exclusive at the present moment.
+
+```
+locked[1718380800000000~] = null     -- lock values ADDED at or after t
+find locked[1700000000~] = "pod-A"   -- ...added at or after t, equal to pod-A
+```
+
+This is distinct from both the single-instant and the range forms. The
+single-instant `foo[t]` binds the value *present at* the instant `t`
+regardless of when it was added; `foo[t~]` keys strictly off the
+add-event, so a value added before `t` (even if it is still present) is
+not in range. The range `foo[t1...t2]` binds anything *present during*
+the interval regardless of add time. The motivating use is stale-lock
+detection: a record whose only lock value was added before the cutoff
+binds to nothing under `locked[<cutoff>~]` and is therefore claimable.
+
+A marker binds a single instant, so it cannot be combined with a range
+(`foo[t1...t2~]` is rejected), and a key still carries at most one
+bracket annotation (`foo[t1~][t2]` is rejected). The leading form
+`foo[~t]` (added-before) is **not** supported and is rejected at parse
+time; it is semantically equivalent to an existence-before range and is
+deferred to that sibling work.
+
+The canonical serialization renders the timestamp as microseconds with a
+trailing `~` and omits any keyword, for example `locked[1700000000~]`.
+
+Modification markers are currently supported only on flat leaf keys, not
+on navigation stops or scope prefixes. Evaluating what a marked read
+returns is a server-side concern and is outside the grammar.
+
 #### Per-stop navigation
 
 Navigation keys carry one bracket per stop. Each annotation binds only

--- a/grammar/grammar.jjt
+++ b/grammar/grammar.jjt
@@ -768,7 +768,9 @@ TimestampSymbol Timestamp() :
 // meaning lives in one place. SEARCH_MATCH is accepted here only so a
 // standalone '~' modification marker (e.g. after a quoted timestamp) is
 // captured into the content; its meaning as a search operator outside
-// brackets is unaffected.
+// brackets is unaffected. The SEARCH_MATCH token also lexes the
+// 'search_match'/'contains' keyword spellings, which are meaningless
+// inside a bracket, so the action rejects those and admits only '~'.
 String KeyBracketParameter() :
 {
   Token word;
@@ -776,7 +778,14 @@ String KeyBracketParameter() :
 }
 {
   (<TIMESTAMP>)?
-  (LOOKAHEAD(2) (word=<QUOTED_STRING> | word=<SIGNED_INTEGER> | word=<SIGNED_DECIMAL> | word=<NUMERIC> | word=<ALPHANUMERIC> | word=<NON_ALPHANUMERIC_AND_ALPHANUMERIC> | word=<ASTERISK_SUFFIXED_STRING> | word=<SEARCH_MATCH>) { parameter += (parameter.equals("")) ? word.image : " " + word.image; })+
+  (LOOKAHEAD(2) (word=<QUOTED_STRING> | word=<SIGNED_INTEGER> | word=<SIGNED_DECIMAL> | word=<NUMERIC> | word=<ALPHANUMERIC> | word=<NON_ALPHANUMERIC_AND_ALPHANUMERIC> | word=<ASTERISK_SUFFIXED_STRING> | word=<SEARCH_MATCH>)
+    {
+      if(word.kind == GrammarConstants.SEARCH_MATCH && !word.image.equals("~")) {
+        throw new ParseException("only the '~' modification marker is allowed "
+            + "inside a key bracket, not the '" + word.image + "' keyword");
+      }
+      parameter += (parameter.equals("")) ? word.image : " " + word.image;
+    })+
   { return parameter; }
 }
 

--- a/grammar/grammar.jjt
+++ b/grammar/grammar.jjt
@@ -763,8 +763,12 @@ TimestampSymbol Timestamp() :
 // Bracket-form key parameter: the raw content between a leaf key's
 // brackets. The leading at/on/during keyword is optional (the brackets
 // themselves are the pivot) and is consumed without being returned.
-// Interpreting the content -- single instant vs. temporal range -- is
-// deferred to Parsing.applyKeyBracket so the meaning lives in one place.
+// Interpreting the content -- single instant, temporal range, or
+// modification marker -- is deferred to Parsing.applyKeyBracket so the
+// meaning lives in one place. SEARCH_MATCH is accepted here only so a
+// standalone '~' modification marker (e.g. after a quoted timestamp) is
+// captured into the content; its meaning as a search operator outside
+// brackets is unaffected.
 String KeyBracketParameter() :
 {
   Token word;
@@ -772,7 +776,7 @@ String KeyBracketParameter() :
 }
 {
   (<TIMESTAMP>)?
-  (LOOKAHEAD(2) (word=<QUOTED_STRING> | word=<SIGNED_INTEGER> | word=<SIGNED_DECIMAL> | word=<NUMERIC> | word=<ALPHANUMERIC> | word=<NON_ALPHANUMERIC_AND_ALPHANUMERIC> | word=<ASTERISK_SUFFIXED_STRING>) { parameter += (parameter.equals("")) ? word.image : " " + word.image; })+
+  (LOOKAHEAD(2) (word=<QUOTED_STRING> | word=<SIGNED_INTEGER> | word=<SIGNED_DECIMAL> | word=<NUMERIC> | word=<ALPHANUMERIC> | word=<NON_ALPHANUMERIC_AND_ALPHANUMERIC> | word=<ASTERISK_SUFFIXED_STRING> | word=<SEARCH_MATCH>) { parameter += (parameter.equals("")) ? word.image : " " + word.image; })+
   { return parameter; }
 }
 

--- a/src/main/java/com/cinchapi/ccl/Parsing.java
+++ b/src/main/java/com/cinchapi/ccl/Parsing.java
@@ -115,14 +115,14 @@ public final class Parsing {
                     indexOfRangeSeparator(timestamp, 0) < 0,
                     "a modification marker binds a single instant, not a "
                             + "range; '%s' combines '%s' with '%s'",
-                    content, RANGE_SEPARATOR, MODIFICATION_MARKER);
+                    trimmed, RANGE_SEPARATOR, MODIFICATION_MARKER);
             return new ModificationKeySymbol(base,
                     new TimestampSymbol(NaturalLanguage.parseMicros(timestamp)));
         }
-        int separator = indexOfRangeSeparator(content, 0);
+        int separator = indexOfRangeSeparator(trimmed, 0);
         if(separator < 0) {
             TimestampSymbol timestamp = new TimestampSymbol(
-                    NaturalLanguage.parseMicros(content.trim()));
+                    NaturalLanguage.parseMicros(trimmed));
             if(base instanceof NavigationKeySymbol) {
                 return NavigationKeySymbol.withTimestampOnLastStop(
                         (NavigationKeySymbol) base, timestamp);
@@ -133,13 +133,13 @@ public final class Parsing {
         }
         else {
             Preconditions.checkArgument(
-                    indexOfRangeSeparator(content,
+                    indexOfRangeSeparator(trimmed,
                             separator + RANGE_SEPARATOR.length()) < 0,
                     "a temporal range has exactly two endpoints separated by "
                             + "a single '%s'; '%s' has more than one",
-                    RANGE_SEPARATOR, content);
-            String startText = content.substring(0, separator).trim();
-            String endText = content
+                    RANGE_SEPARATOR, trimmed);
+            String startText = trimmed.substring(0, separator).trim();
+            String endText = trimmed
                     .substring(separator + RANGE_SEPARATOR.length()).trim();
             TimestampSymbol start = startText.isEmpty() ? null
                     : new TimestampSymbol(

--- a/src/main/java/com/cinchapi/ccl/Parsing.java
+++ b/src/main/java/com/cinchapi/ccl/Parsing.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import com.cinchapi.ccl.grammar.ConjunctionSymbol;
 import com.cinchapi.ccl.grammar.ExpressionSymbol;
 import com.cinchapi.ccl.grammar.KeyTokenSymbol;
+import com.cinchapi.ccl.grammar.ModificationKeySymbol;
 import com.cinchapi.ccl.grammar.NavigationKeySymbol;
 import com.cinchapi.ccl.grammar.OperatorSymbol;
 import com.cinchapi.ccl.grammar.ParenthesisSymbol;
@@ -61,29 +62,63 @@ public final class Parsing {
     private static final String RANGE_SEPARATOR = "...";
 
     /**
+     * The literal marker that, when trailing a bracket timestamp, denotes
+     * an addition-relative binding (for example {@code foo[t1~]}): the
+     * values whose add occurred at or after the timestamp.
+     */
+    private static final String MODIFICATION_MARKER = "~";
+
+    /**
      * Interpret the raw {@code content} of a leaf key's bracket parameter
      * and pair it with {@code base} as the appropriate parameterized key.
      *
-     * <p>Content containing the range separator {@code ...} produces a
-     * {@link TemporalRangeKeySymbol} over the half-open interval its
-     * endpoints describe; either endpoint may be omitted for an
-     * open-ended range. All other content is a single instant and
-     * produces a {@link TemporalKeySymbol}, or, when {@code base} is a
-     * {@link NavigationKeySymbol}, folds the timestamp onto the path's
-     * last stop.
+     * <p>Content ending in the modification marker {@code ~} produces a
+     * {@link ModificationKeySymbol} bound to the values added at or after
+     * the timestamp ({@code foo[t1~]}). Content containing the range
+     * separator {@code ...} produces a {@link TemporalRangeKeySymbol} over
+     * the half-open interval its endpoints describe; either endpoint may
+     * be omitted for an open-ended range. All other content is a single
+     * instant and produces a {@link TemporalKeySymbol}, or, when
+     * {@code base} is a {@link NavigationKeySymbol}, folds the timestamp
+     * onto the path's last stop.
+     *
+     * <p>The leading modification form {@code key[~t]} (added-before) is
+     * not yet supported and is rejected; it is semantically equivalent to
+     * an existence-before range and is deferred to that sibling work.
      *
      * @param base the key the bracket parameter binds to
      * @param content the raw bracket content; the leading {@code at} /
      *            {@code on} / {@code during} keyword, if any, has already
      *            been consumed by the grammar
      * @return the parameterized {@link KeyTokenSymbol}
-     * @throws IllegalArgumentException if a range binding is applied to a
-     *             navigation key, if both endpoints are omitted, if more
-     *             than one range separator is present, or if an endpoint
-     *             cannot be parsed as a timestamp
+     * @throws IllegalArgumentException if a range or modification binding
+     *             is applied to a navigation key, if a range omits both
+     *             endpoints or has more than one separator, if the
+     *             unsupported leading {@code ~t} form is used, or if a
+     *             timestamp cannot be parsed
      */
     public static KeyTokenSymbol<?> applyKeyBracket(KeyTokenSymbol<?> base,
             String content) {
+        String trimmed = content.trim();
+        if(trimmed.startsWith(MODIFICATION_MARKER)) {
+            throw new IllegalArgumentException(
+                    "the leading modification form key[~t] (added-before) is "
+                            + "not yet supported; use a single instant key[t] "
+                            + "or a range key[t1...t2]");
+        }
+        if(trimmed.endsWith(MODIFICATION_MARKER)) {
+            String timestamp = trimmed
+                    .substring(0,
+                            trimmed.length() - MODIFICATION_MARKER.length())
+                    .trim();
+            Preconditions.checkArgument(
+                    indexOfRangeSeparator(timestamp, 0) < 0,
+                    "a modification marker binds a single instant, not a "
+                            + "range; '%s' combines '%s' with '%s'",
+                    content, RANGE_SEPARATOR, MODIFICATION_MARKER);
+            return new ModificationKeySymbol(base,
+                    new TimestampSymbol(NaturalLanguage.parseMicros(timestamp)));
+        }
         int separator = indexOfRangeSeparator(content, 0);
         if(separator < 0) {
             TimestampSymbol timestamp = new TimestampSymbol(

--- a/src/main/java/com/cinchapi/ccl/generated/Grammar.java
+++ b/src/main/java/com/cinchapi/ccl/generated/Grammar.java
@@ -1621,8 +1621,12 @@ timestamp += (timestamp.equals("")) ? word.image : " " + word.image;
 // Bracket-form key parameter: the raw content between a leaf key's
 // brackets. The leading at/on/during keyword is optional (the brackets
 // themselves are the pivot) and is consumed without being returned.
-// Interpreting the content -- single instant vs. temporal range -- is
-// deferred to Parsing.applyKeyBracket so the meaning lives in one place.
+// Interpreting the content -- single instant, temporal range, or
+// modification marker -- is deferred to Parsing.applyKeyBracket so the
+// meaning lives in one place. SEARCH_MATCH is accepted here only so a
+// standalone '~' modification marker (e.g. after a quoted timestamp) is
+// captured into the content; its meaning as a search operator outside
+// brackets is unaffected.
   final public String KeyBracketParameter() throws ParseException {Token word;
   String parameter = "";
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -1663,6 +1667,10 @@ timestamp += (timestamp.equals("")) ? word.image : " " + word.image;
         }
       case ASTERISK_SUFFIXED_STRING:{
         word = jj_consume_token(ASTERISK_SUFFIXED_STRING);
+        break;
+        }
+      case SEARCH_MATCH:{
+        word = jj_consume_token(SEARCH_MATCH);
         break;
         }
       default:
@@ -5615,24 +5623,6 @@ keys.add(key);
     finally { jj_save(70, xla); }
   }
 
-  private boolean jj_3_29()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
-    jj_scanpos = xsp;
-    if (jj_3R_40()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3_54()
- {
-    if (jj_3R_55()) return true;
-    if (jj_scan_token(QUOTED_STRING)) return true;
-    return false;
-  }
-
   private boolean jj_3R_22()
  {
     if (jj_3R_67()) return true;
@@ -5671,9 +5661,23 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3R_39()
+ {
+    if (jj_scan_token(NUMERIC)) return true;
+    if (jj_scan_token(COMMA)) return true;
+    return false;
+  }
+
   private boolean jj_3R_23()
  {
     if (jj_3R_69()) return true;
+    return false;
+  }
+
+  private boolean jj_3_31()
+ {
+    if (jj_scan_token(OPEN_BRACKET)) return true;
+    if (jj_scan_token(NUMERIC)) return true;
     return false;
   }
 
@@ -5685,20 +5689,6 @@ keys.add(key);
     jj_scanpos = xsp;
     if (jj_scan_token(83)) return true;
     }
-    return false;
-  }
-
-  private boolean jj_3R_39()
- {
-    if (jj_scan_token(NUMERIC)) return true;
-    if (jj_scan_token(COMMA)) return true;
-    return false;
-  }
-
-  private boolean jj_3_31()
- {
-    if (jj_scan_token(OPEN_BRACKET)) return true;
-    if (jj_scan_token(NUMERIC)) return true;
     return false;
   }
 
@@ -5714,12 +5704,6 @@ keys.add(key);
     }
     }
     if (jj_scan_token(NUMERIC)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_108()
- {
-    if (jj_scan_token(BINARY_OPERATOR)) return true;
     return false;
   }
 
@@ -5742,7 +5726,31 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3R_108()
+ {
+    if (jj_scan_token(BINARY_OPERATOR)) return true;
+    return false;
+  }
+
   private boolean jj_3R_65()
+ {
+    if (jj_scan_token(NUMERIC)) return true;
+    if (jj_scan_token(COMMA)) return true;
+    return false;
+  }
+
+  private boolean jj_3_28()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(53)) {
+    jj_scanpos = xsp;
+    if (jj_3R_39()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_38()
  {
     if (jj_scan_token(NUMERIC)) return true;
     if (jj_scan_token(COMMA)) return true;
@@ -5763,17 +5771,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_28()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
-    jj_scanpos = xsp;
-    if (jj_3R_39()) return true;
-    }
-    return false;
-  }
-
   private boolean jj_3_2()
  {
     Token xsp;
@@ -5784,13 +5781,6 @@ keys.add(key);
     if (jj_3R_25()) jj_scanpos = xsp;
     xsp = jj_scanpos;
     if (jj_3R_26()) jj_scanpos = xsp;
-    return false;
-  }
-
-  private boolean jj_3R_38()
- {
-    if (jj_scan_token(NUMERIC)) return true;
-    if (jj_scan_token(COMMA)) return true;
     return false;
   }
 
@@ -5808,12 +5798,6 @@ keys.add(key);
     }
     }
     }
-    return false;
-  }
-
-  private boolean jj_3R_102()
- {
-    if (jj_scan_token(LINKS_TO)) return true;
     return false;
   }
 
@@ -5849,24 +5833,16 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_1()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(56)) jj_scanpos = xsp;
-    if (jj_3R_22()) return true;
-    xsp = jj_scanpos;
-    if (jj_3R_23()) jj_scanpos = xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_24()) jj_scanpos = xsp;
-    if (jj_scan_token(102)) return true;
-    return false;
-  }
-
   private boolean jj_3R_37()
  {
     if (jj_scan_token(NUMERIC)) return true;
     if (jj_scan_token(COMMA)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_102()
+ {
+    if (jj_scan_token(LINKS_TO)) return true;
     return false;
   }
 
@@ -5881,9 +5857,17 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_116()
+  private boolean jj_3_1()
  {
-    if (jj_scan_token(QUOTED_STRING)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(56)) jj_scanpos = xsp;
+    if (jj_3R_22()) return true;
+    xsp = jj_scanpos;
+    if (jj_3R_23()) jj_scanpos = xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_24()) jj_scanpos = xsp;
+    if (jj_scan_token(102)) return true;
     return false;
   }
 
@@ -5891,6 +5875,12 @@ keys.add(key);
  {
     if (jj_scan_token(OPEN_BRACKET)) return true;
     if (jj_scan_token(NUMERIC)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_116()
+ {
+    if (jj_scan_token(QUOTED_STRING)) return true;
     return false;
   }
 
@@ -6067,17 +6057,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_100()
- {
-    Token xsp;
-    if (jj_3_16()) return true;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3_16()) { jj_scanpos = xsp; break; }
-    }
-    return false;
-  }
-
   private boolean jj_3_66()
  {
     Token xsp;
@@ -6085,6 +6064,17 @@ keys.add(key);
     if (jj_scan_token(53)) {
     jj_scanpos = xsp;
     if (jj_3R_63()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_100()
+ {
+    Token xsp;
+    if (jj_3_16()) return true;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3_16()) { jj_scanpos = xsp; break; }
     }
     return false;
   }
@@ -6142,16 +6132,16 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_112()
- {
-    if (jj_scan_token(QUOTED_STRING)) return true;
-    return false;
-  }
-
   private boolean jj_3_48()
  {
     if (jj_3R_42()) return true;
     if (jj_scan_token(WHERE)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_112()
+ {
+    if (jj_scan_token(QUOTED_STRING)) return true;
     return false;
   }
 
@@ -6300,15 +6290,15 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_103()
- {
-    if (jj_scan_token(NUMERIC)) return true;
-    return false;
-  }
-
   private boolean jj_3R_36()
  {
     if (jj_scan_token(OPEN_BRACKET)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_103()
+ {
+    if (jj_scan_token(NUMERIC)) return true;
     return false;
   }
 
@@ -6326,12 +6316,6 @@ keys.add(key);
     jj_scanpos = xsp;
     if (jj_scan_token(88)) return true;
     }
-    return false;
-  }
-
-  private boolean jj_3R_114()
- {
-    if (jj_scan_token(QUOTED_STRING)) return true;
     return false;
   }
 
@@ -6378,6 +6362,12 @@ keys.add(key);
  {
     if (jj_scan_token(COMMA)) return true;
     if (jj_3R_27()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_114()
+ {
+    if (jj_scan_token(QUOTED_STRING)) return true;
     return false;
   }
 
@@ -6461,17 +6451,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_113()
- {
-    Token xsp;
-    if (jj_3_12()) return true;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3_12()) { jj_scanpos = xsp; break; }
-    }
-    return false;
-  }
-
   private boolean jj_3_24()
  {
     Token xsp;
@@ -6497,23 +6476,14 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_107()
+  private boolean jj_3R_113()
  {
     Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3_13()) {
-    jj_scanpos = xsp;
-    if (jj_3R_113()) {
-    jj_scanpos = xsp;
-    if (jj_3R_114()) return true;
+    if (jj_3_12()) return true;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3_12()) { jj_scanpos = xsp; break; }
     }
-    }
-    return false;
-  }
-
-  private boolean jj_3_13()
- {
-    if (jj_3R_32()) return true;
     return false;
   }
 
@@ -6532,6 +6502,26 @@ keys.add(key);
  {
     if (jj_scan_token(ALPHANUMERIC)) return true;
     if (jj_scan_token(OPEN_PARENTHESES)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_107()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3_13()) {
+    jj_scanpos = xsp;
+    if (jj_3R_113()) {
+    jj_scanpos = xsp;
+    if (jj_3R_114()) return true;
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3_13()
+ {
+    if (jj_3R_32()) return true;
     return false;
   }
 
@@ -6597,14 +6587,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_11()
- {
-    if (jj_scan_token(OPEN_BRACKET)) return true;
-    if (jj_3R_31()) return true;
-    if (jj_scan_token(CLOSE_BRACKET)) return true;
-    return false;
-  }
-
   private boolean jj_3_63()
  {
     if (jj_3R_43()) return true;
@@ -6633,6 +6615,21 @@ keys.add(key);
     jj_scanpos = xsp;
     if (jj_3R_48()) return true;
     }
+    return false;
+  }
+
+  private boolean jj_3_11()
+ {
+    if (jj_scan_token(OPEN_BRACKET)) return true;
+    if (jj_3R_31()) return true;
+    if (jj_scan_token(CLOSE_BRACKET)) return true;
+    return false;
+  }
+
+  private boolean jj_3_41()
+ {
+    if (jj_scan_token(OPEN_BRACKET)) return true;
+    if (jj_scan_token(NUMERIC)) return true;
     return false;
   }
 
@@ -6667,38 +6664,15 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_41()
- {
-    if (jj_scan_token(OPEN_BRACKET)) return true;
-    if (jj_scan_token(NUMERIC)) return true;
-    return false;
-  }
-
-  private boolean jj_3_10()
- {
-    if (jj_3R_30()) return true;
-    return false;
-  }
-
   private boolean jj_3_23()
  {
     if (jj_3R_30()) return true;
     return false;
   }
 
-  private boolean jj_3R_43()
+  private boolean jj_3_10()
  {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3_10()) {
-    jj_scanpos = xsp;
-    if (jj_3R_75()) {
-    jj_scanpos = xsp;
-    if (jj_3R_76()) return true;
-    }
-    }
-    xsp = jj_scanpos;
-    if (jj_3_11()) jj_scanpos = xsp;
+    if (jj_3R_30()) return true;
     return false;
   }
 
@@ -6717,6 +6691,22 @@ keys.add(key);
  {
     if (jj_3R_43()) return true;
     if (jj_scan_token(COMMA)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_43()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3_10()) {
+    jj_scanpos = xsp;
+    if (jj_3R_75()) {
+    jj_scanpos = xsp;
+    if (jj_3R_76()) return true;
+    }
+    }
+    xsp = jj_scanpos;
+    if (jj_3_11()) jj_scanpos = xsp;
     return false;
   }
 
@@ -6751,17 +6741,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_28()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_71()) {
-    jj_scanpos = xsp;
-    if (jj_3R_72()) return true;
-    }
-    return false;
-  }
-
   private boolean jj_3_61()
  {
     Token xsp;
@@ -6769,6 +6748,17 @@ keys.add(key);
     if (jj_scan_token(53)) {
     jj_scanpos = xsp;
     if (jj_3R_59()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_28()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_71()) {
+    jj_scanpos = xsp;
+    if (jj_3R_72()) return true;
     }
     return false;
   }
@@ -6786,13 +6776,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_9()
- {
-    if (jj_3R_28()) return true;
-    if (jj_3R_29()) return true;
-    return false;
-  }
-
   private boolean jj_3_60()
  {
     Token xsp;
@@ -6801,6 +6784,13 @@ keys.add(key);
     jj_scanpos = xsp;
     if (jj_3R_58()) return true;
     }
+    return false;
+  }
+
+  private boolean jj_3_9()
+ {
+    if (jj_3R_28()) return true;
+    if (jj_3R_29()) return true;
     return false;
   }
 
@@ -6823,6 +6813,17 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3_36()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(53)) {
+    jj_scanpos = xsp;
+    if (jj_3R_45()) return true;
+    }
+    return false;
+  }
+
   private boolean jj_3_3()
  {
     if (jj_3R_27()) return true;
@@ -6832,17 +6833,6 @@ keys.add(key);
   private boolean jj_3_5()
  {
     if (jj_3R_27()) return true;
-    return false;
-  }
-
-  private boolean jj_3_36()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
-    jj_scanpos = xsp;
-    if (jj_3R_45()) return true;
-    }
     return false;
   }
 
@@ -6931,14 +6921,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_98()
- {
-    if (jj_3R_108()) return true;
-    if (jj_3R_109()) return true;
-    if (jj_3R_109()) return true;
-    return false;
-  }
-
   private boolean jj_3R_80()
  {
     if (jj_3R_89()) return true;
@@ -6956,16 +6938,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_97()
- {
-    if (jj_3R_106()) return true;
-    if (jj_3R_107()) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3_5()) jj_scanpos = xsp;
-    return false;
-  }
-
   private boolean jj_3R_70()
  {
     Token xsp;
@@ -6974,6 +6946,24 @@ keys.add(key);
     jj_scanpos = xsp;
     if (jj_3R_81()) return true;
     }
+    return false;
+  }
+
+  private boolean jj_3R_98()
+ {
+    if (jj_3R_108()) return true;
+    if (jj_3R_109()) return true;
+    if (jj_3R_109()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_97()
+ {
+    if (jj_3R_106()) return true;
+    if (jj_3R_107()) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3_5()) jj_scanpos = xsp;
     return false;
   }
 
@@ -6997,35 +6987,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_93()
- {
-    if (jj_3R_43()) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_95()) {
-    jj_scanpos = xsp;
-    if (jj_3R_96()) {
-    jj_scanpos = xsp;
-    if (jj_3R_97()) {
-    jj_scanpos = xsp;
-    if (jj_3R_98()) {
-    jj_scanpos = xsp;
-    if (jj_3R_99()) return true;
-    }
-    }
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3_8()
- {
-    if (jj_3R_28()) return true;
-    if (jj_3R_29()) return true;
-    if (jj_3R_94()) return true;
-    return false;
-  }
-
   private boolean jj_3_21()
  {
     Token xsp;
@@ -7045,6 +7006,27 @@ keys.add(key);
     if (jj_scan_token(96)) return true;
     }
     }
+    }
+    }
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_93()
+ {
+    if (jj_3R_43()) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_95()) {
+    jj_scanpos = xsp;
+    if (jj_3R_96()) {
+    jj_scanpos = xsp;
+    if (jj_3R_97()) {
+    jj_scanpos = xsp;
+    if (jj_3R_98()) {
+    jj_scanpos = xsp;
+    if (jj_3R_99()) return true;
     }
     }
     }
@@ -7080,6 +7062,14 @@ keys.add(key);
     }
     }
     }
+    return false;
+  }
+
+  private boolean jj_3_8()
+ {
+    if (jj_3R_28()) return true;
+    if (jj_3R_29()) return true;
+    if (jj_3R_94()) return true;
     return false;
   }
 
@@ -7173,18 +7163,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_79()
- {
-    if (jj_scan_token(CONJUNCTION)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_68()
- {
-    if (jj_scan_token(DISJUNCTION)) return true;
-    return false;
-  }
-
   private boolean jj_3R_42()
  {
     Token xsp;
@@ -7196,10 +7174,9 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_91()
+  private boolean jj_3R_79()
  {
-    if (jj_scan_token(NAVIGATION_SCOPE_OPEN)) return true;
-    if (jj_3R_22()) return true;
+    if (jj_scan_token(CONJUNCTION)) return true;
     return false;
   }
 
@@ -7210,9 +7187,22 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3R_68()
+ {
+    if (jj_scan_token(DISJUNCTION)) return true;
+    return false;
+  }
+
   private boolean jj_3_56()
  {
     if (jj_scan_token(NUMERIC)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_91()
+ {
+    if (jj_scan_token(NAVIGATION_SCOPE_OPEN)) return true;
+    if (jj_3R_22()) return true;
     return false;
   }
 
@@ -7233,18 +7223,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_26()
- {
-    if (jj_3R_70()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_88()
- {
-    if (jj_3R_92()) return true;
-    return false;
-  }
-
   private boolean jj_3R_40()
  {
     if (jj_scan_token(NUMERIC)) return true;
@@ -7256,13 +7234,6 @@ keys.add(key);
  {
     if (jj_scan_token(NUMERIC)) return true;
     if (jj_scan_token(COMMA)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_87()
- {
-    if (jj_scan_token(OPEN_PARENTHESES)) return true;
-    if (jj_3R_22()) return true;
     return false;
   }
 
@@ -7282,7 +7253,10 @@ keys.add(key);
     jj_scanpos = xsp;
     if (jj_scan_token(97)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(96)) return true;
+    if (jj_scan_token(96)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(82)) return true;
+    }
     }
     }
     }
@@ -7292,9 +7266,52 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3R_26()
+ {
+    if (jj_3R_70()) return true;
+    return false;
+  }
+
   private boolean jj_3R_84()
  {
     if (jj_scan_token(OPEN_BRACKET)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_88()
+ {
+    if (jj_3R_92()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_31()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(55)) jj_scanpos = xsp;
+    if (jj_3_20()) return true;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3_20()) { jj_scanpos = xsp; break; }
+    }
+    return false;
+  }
+
+  private boolean jj_3_30()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(53)) {
+    jj_scanpos = xsp;
+    if (jj_3R_41()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_87()
+ {
+    if (jj_scan_token(OPEN_PARENTHESES)) return true;
+    if (jj_3R_22()) return true;
     return false;
   }
 
@@ -7344,30 +7361,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_31()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(55)) jj_scanpos = xsp;
-    if (jj_3_20()) return true;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3_20()) { jj_scanpos = xsp; break; }
-    }
-    return false;
-  }
-
-  private boolean jj_3_30()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
-    jj_scanpos = xsp;
-    if (jj_3R_41()) return true;
-    }
-    return false;
-  }
-
   private boolean jj_3R_77()
  {
     Token xsp;
@@ -7375,6 +7368,21 @@ keys.add(key);
     if (jj_3R_84()) {
     jj_scanpos = xsp;
     if (jj_3R_85()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3_33()
+ {
+    if (jj_3R_43()) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(40)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(37)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(39)) return true;
+    }
     }
     return false;
   }
@@ -7396,18 +7404,21 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_33()
+  private boolean jj_3_29()
  {
-    if (jj_3R_43()) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(40)) {
+    if (jj_scan_token(53)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(37)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(39)) return true;
+    if (jj_3R_40()) return true;
     }
-    }
+    return false;
+  }
+
+  private boolean jj_3_54()
+ {
+    if (jj_3R_55()) return true;
+    if (jj_scan_token(QUOTED_STRING)) return true;
     return false;
   }
 
@@ -7446,7 +7457,7 @@ keys.add(key);
 	   jj_la1_1 = new int[] {0x1000000,0x0,0x0,0x1f,0x0,0x1000000,0x0,0x0,0x1f,0x0,0x8000000,0x4000000,0x2080000,0xf0000000,0x2000000,0x8000000,0x4000000,0x2080000,0xf0000000,0x2000000,0x2000000,0x0,0x2000000,0x2000000,0x0,0x2000000,0x0,0x0,0x0,0x0,0x80000,0x0,0x0,0x0,0x0,0x0,0xd0000000,0x0,0x0,0x800000,0x0,0x800400,0x0,0x0,0x800400,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xc2000000,0x800000,0xc0000000,0x0,0x0,0x0,0x0,0x100000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200000,0x0,0x100000,0x0,0x1f,0x0,0x2a0,0x0,0x2a0,0xa0,0x0,0x1a0,0x0,0x1a0,0x0,0x1a0,0x0,0x0,0xa0,0xa0,0x2e0,0x0,0x2e0,0x0,0x0,0x0,0x800400,0x1a0,0x800400,0x0,0x0,0x800400,0x0,0x0,0x0,0x800400,0x0,0x0,0x1000000,0x1a0,0x800400,0x0,0x0,0x800400,0x0,0x0,0x0,0x800400,0x0,0x0,0x1000000,0x800400,0x0,0x0,0x800400,0x800400,0x1000000,0x0,0x800400,0x0,0x0,0x800400,0x0,0x0,0x1a0,0x800400,0x0,0x0,0x800400,0x0,0x0,0x0,0x1a0,0x800400,0x0,0x0,0x800400,0x0,0x0,0x0,0x800400,0x0,0x0,0x1a0,0x800400,0x0,0x0,0x800400,0x0,0x0,0x0,0x800400,0x800400,0x800400,0x10001a0,0x0,0x800400,0x0,0x0,0x800400,0x800400,0x800400,0xa0,0x800400,0x2000000,0x800400,0xa0,0x200,0x100,0xa0,0x200,0x200,0x200,0x2000000,0x0,0x4000,0x800400,0x2000000,0x800400,0x1a0,0x800400,0x800400,0x0,0x10001a0,0xa0,0xa0,0x200,0x100,0x800400,0x800400,0x0,0x1,0xa0,0x0,0xa0,0x0,0x2000000,0x1c,0x0,0x0,0x1a0,0x800400,0x1a0,0x800400,0x800400,0x800400,0x1000000,0x0,0x0,0x200000,0x0,0x0,0x200000,0x0,0x0,0x2200000,};
 	}
 	private static void jj_la1_init_2() {
-	   jj_la1_2 = new int[] {0x0,0x8000,0x7000,0x0,0x3d00f000,0x0,0x8000,0x7000,0x0,0x3d00f000,0x0,0x0,0x7d000000,0xc07c0,0x3d000000,0x0,0x0,0x7d000000,0xc07c0,0x3d000000,0x1d000000,0x20000000,0x3d000000,0x1d000000,0x20000000,0x3d000000,0x3d000000,0x3d200000,0x3d000000,0x3d000000,0x3d200000,0x1d000000,0x1d200000,0x3d000000,0x3d200000,0x780,0x0,0xc0000,0x1d200000,0x0,0x1d200000,0x0,0x1d200000,0x1d200000,0x0,0x1d200000,0x4000,0x3000,0x7000,0x3000,0x2000000,0x30000,0x3d000000,0x0,0x0,0x30000,0x10000000,0x3d000000,0x3c000000,0x2000000,0x3c000000,0x5000000,0x2000000,0x5000000,0x5000000,0x2000000,0x5000000,0x5000000,0x3c000000,0x2000000,0x3c000000,0x0,0x0,0x0,0x1000000,0x0,0x0,0x1000000,0x0,0x1000000,0x0,0x1000000,0x0,0x1000000,0x1000000,0x0,0x0,0x0,0x1000000,0x0,0x0,0x1000000,0x0,0x0,0x0,0x0,0x8000,0x7000,0x0,0x8000,0x7000,0x1000000,0x0,0x8000,0x7000,0x0,0x0,0x0,0x8000,0x7000,0x0,0x8000,0x7000,0x1000000,0x0,0x8000,0x7000,0x0,0x0,0x8000,0x7000,0x0,0x0,0x0,0x1000000,0x0,0x8000,0x7000,0x0,0x8000,0x7000,0x0,0x0,0x8000,0x7000,0x0,0x8000,0x7000,0x1000000,0x0,0x0,0x8000,0x7000,0x0,0x8000,0x7000,0x1000000,0x0,0x8000,0x7000,0x0,0x0,0x8000,0x7000,0x0,0x8000,0x7000,0x1000000,0x0,0x0,0x0,0x0,0x1000000,0x0,0x8000,0x7000,0x0,0x0,0x0,0x0,0x0,0x3d000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3d000000,0x1000000,0x0,0x0,0x3d000000,0x0,0x0,0x0,0x0,0x1000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1000000,0x0,0x0,0x1000000,0x0,0x1000000,0x3d000000,0x0,0x1000000,0x1000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2000000,0x2000000,0x3d200000,0x2000000,0x2000000,0x1000000,0x2000000,0x2000000,0x3d000000,};
+	   jj_la1_2 = new int[] {0x0,0x8000,0x7000,0x0,0x3d00f000,0x0,0x8000,0x7000,0x0,0x3d00f000,0x0,0x0,0x7d000000,0xc07c0,0x3d000000,0x0,0x0,0x7d000000,0xc07c0,0x3d000000,0x1d000000,0x20000000,0x3d000000,0x1d000000,0x20000000,0x3d000000,0x3d000000,0x3d200000,0x3d000000,0x3d000000,0x3d200000,0x1d000000,0x1d200000,0x3d000000,0x3d200000,0x780,0x0,0xc0000,0x1d200000,0x0,0x1d240000,0x0,0x1d200000,0x1d200000,0x0,0x1d200000,0x4000,0x3000,0x7000,0x3000,0x2000000,0x30000,0x3d000000,0x0,0x0,0x30000,0x10000000,0x3d000000,0x3c000000,0x2000000,0x3c000000,0x5000000,0x2000000,0x5000000,0x5000000,0x2000000,0x5000000,0x5000000,0x3c000000,0x2000000,0x3c000000,0x0,0x0,0x0,0x1000000,0x0,0x0,0x1000000,0x0,0x1000000,0x0,0x1000000,0x0,0x1000000,0x1000000,0x0,0x0,0x0,0x1000000,0x0,0x0,0x1000000,0x0,0x0,0x0,0x0,0x8000,0x7000,0x0,0x8000,0x7000,0x1000000,0x0,0x8000,0x7000,0x0,0x0,0x0,0x8000,0x7000,0x0,0x8000,0x7000,0x1000000,0x0,0x8000,0x7000,0x0,0x0,0x8000,0x7000,0x0,0x0,0x0,0x1000000,0x0,0x8000,0x7000,0x0,0x8000,0x7000,0x0,0x0,0x8000,0x7000,0x0,0x8000,0x7000,0x1000000,0x0,0x0,0x8000,0x7000,0x0,0x8000,0x7000,0x1000000,0x0,0x8000,0x7000,0x0,0x0,0x8000,0x7000,0x0,0x8000,0x7000,0x1000000,0x0,0x0,0x0,0x0,0x1000000,0x0,0x8000,0x7000,0x0,0x0,0x0,0x0,0x0,0x3d000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3d000000,0x1000000,0x0,0x0,0x3d000000,0x0,0x0,0x0,0x0,0x1000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1000000,0x0,0x0,0x1000000,0x0,0x1000000,0x3d000000,0x0,0x1000000,0x1000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2000000,0x2000000,0x3d200000,0x2000000,0x2000000,0x1000000,0x2000000,0x2000000,0x3d000000,};
 	}
 	private static void jj_la1_init_3() {
 	   jj_la1_3 = new int[] {0x0,0x0,0x0,0x0,0x1,0x0,0x0,0x0,0x0,0x1,0x0,0x0,0x1,0x0,0x1,0x0,0x0,0x1,0x0,0x1,0x0,0x1,0x1,0x0,0x1,0x1,0x3,0x3,0x183,0x183,0x183,0x3,0x3,0x3,0x3,0x0,0x0,0x0,0x3,0x0,0x3,0x0,0x3,0x3,0x0,0x3,0x0,0x0,0x0,0x0,0x0,0x0,0x1,0x0,0x0,0x0,0x0,0x1,0x1,0x0,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1,0x0,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1,0x0,0x0,0x0,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3,0x0,0x0,0x0,0x0,0x0,0x1,};

--- a/src/main/java/com/cinchapi/ccl/generated/Grammar.java
+++ b/src/main/java/com/cinchapi/ccl/generated/Grammar.java
@@ -1626,7 +1626,9 @@ timestamp += (timestamp.equals("")) ? word.image : " " + word.image;
 // meaning lives in one place. SEARCH_MATCH is accepted here only so a
 // standalone '~' modification marker (e.g. after a quoted timestamp) is
 // captured into the content; its meaning as a search operator outside
-// brackets is unaffected.
+// brackets is unaffected. The SEARCH_MATCH token also lexes the
+// 'search_match'/'contains' keyword spellings, which are meaningless
+// inside a bracket, so the action rejects those and admits only '~'.
   final public String KeyBracketParameter() throws ParseException {Token word;
   String parameter = "";
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -1678,7 +1680,11 @@ timestamp += (timestamp.equals("")) ? word.image : " " + word.image;
         jj_consume_token(-1);
         throw new ParseException();
       }
-parameter += (parameter.equals("")) ? word.image : " " + word.image;
+if(word.kind == GrammarConstants.SEARCH_MATCH && !word.image.equals("~")) {
+        {if (true) throw new ParseException("only the '~' modification marker is allowed "
+            + "inside a key bracket, not the '" + word.image + "' keyword");}
+      }
+      parameter += (parameter.equals("")) ? word.image : " " + word.image;
       if (jj_2_20(2)) {
         ;
       } else {
@@ -5623,6 +5629,20 @@ keys.add(key);
     finally { jj_save(70, xla); }
   }
 
+  private boolean jj_3R_39()
+ {
+    if (jj_scan_token(NUMERIC)) return true;
+    if (jj_scan_token(COMMA)) return true;
+    return false;
+  }
+
+  private boolean jj_3_31()
+ {
+    if (jj_scan_token(OPEN_BRACKET)) return true;
+    if (jj_scan_token(NUMERIC)) return true;
+    return false;
+  }
+
   private boolean jj_3R_22()
  {
     if (jj_3R_67()) return true;
@@ -5642,52 +5662,6 @@ keys.add(key);
     while (true) {
       xsp = jj_scanpos;
       if (jj_3_19()) { jj_scanpos = xsp; break; }
-    }
-    return false;
-  }
-
-  private boolean jj_3_32()
- {
-    if (jj_3R_42()) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(40)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(37)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(39)) return true;
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_39()
- {
-    if (jj_scan_token(NUMERIC)) return true;
-    if (jj_scan_token(COMMA)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_23()
- {
-    if (jj_3R_69()) return true;
-    return false;
-  }
-
-  private boolean jj_3_31()
- {
-    if (jj_scan_token(OPEN_BRACKET)) return true;
-    if (jj_scan_token(NUMERIC)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_29()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(82)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(83)) return true;
     }
     return false;
   }
@@ -5726,9 +5700,20 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_108()
+  private boolean jj_3R_23()
  {
-    if (jj_scan_token(BINARY_OPERATOR)) return true;
+    if (jj_3R_69()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_29()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(82)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(83)) return true;
+    }
     return false;
   }
 
@@ -5757,6 +5742,12 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3R_108()
+ {
+    if (jj_scan_token(BINARY_OPERATOR)) return true;
+    return false;
+  }
+
   private boolean jj_3R_106()
  {
     Token xsp;
@@ -5781,23 +5772,6 @@ keys.add(key);
     if (jj_3R_25()) jj_scanpos = xsp;
     xsp = jj_scanpos;
     if (jj_3R_26()) jj_scanpos = xsp;
-    return false;
-  }
-
-  private boolean jj_3R_104()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(71)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(72)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(73)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(74)) return true;
-    }
-    }
-    }
     return false;
   }
 
@@ -5840,12 +5814,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_102()
- {
-    if (jj_scan_token(LINKS_TO)) return true;
-    return false;
-  }
-
   private boolean jj_3_27()
  {
     Token xsp;
@@ -5854,6 +5822,36 @@ keys.add(key);
     jj_scanpos = xsp;
     if (jj_3R_38()) return true;
     }
+    return false;
+  }
+
+  private boolean jj_3R_104()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(71)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(72)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(73)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(74)) return true;
+    }
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3_52()
+ {
+    if (jj_scan_token(OPEN_BRACKET)) return true;
+    if (jj_scan_token(NUMERIC)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_102()
+ {
+    if (jj_scan_token(LINKS_TO)) return true;
     return false;
   }
 
@@ -5868,19 +5866,6 @@ keys.add(key);
     xsp = jj_scanpos;
     if (jj_3R_24()) jj_scanpos = xsp;
     if (jj_scan_token(102)) return true;
-    return false;
-  }
-
-  private boolean jj_3_52()
- {
-    if (jj_scan_token(OPEN_BRACKET)) return true;
-    if (jj_scan_token(NUMERIC)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_116()
- {
-    if (jj_scan_token(QUOTED_STRING)) return true;
     return false;
   }
 
@@ -5924,6 +5909,30 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3R_116()
+ {
+    if (jj_scan_token(QUOTED_STRING)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_52()
+ {
+    if (jj_scan_token(NUMERIC)) return true;
+    if (jj_scan_token(COMMA)) return true;
+    return false;
+  }
+
+  private boolean jj_3_46()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(53)) {
+    jj_scanpos = xsp;
+    if (jj_3R_53()) return true;
+    }
+    return false;
+  }
+
   private boolean jj_3R_115()
  {
     Token xsp;
@@ -5950,6 +5959,13 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3R_63()
+ {
+    if (jj_scan_token(NUMERIC)) return true;
+    if (jj_scan_token(COMMA)) return true;
+    return false;
+  }
+
   private boolean jj_3R_109()
  {
     Token xsp;
@@ -5967,37 +5983,6 @@ keys.add(key);
   private boolean jj_3_18()
  {
     if (jj_3R_32()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_52()
- {
-    if (jj_scan_token(NUMERIC)) return true;
-    if (jj_scan_token(COMMA)) return true;
-    return false;
-  }
-
-  private boolean jj_3_46()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
-    jj_scanpos = xsp;
-    if (jj_3R_53()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_63()
- {
-    if (jj_scan_token(NUMERIC)) return true;
-    if (jj_scan_token(COMMA)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_101()
- {
-    if (jj_scan_token(QUOTED_STRING)) return true;
     return false;
   }
 
@@ -6034,6 +6019,38 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3R_101()
+ {
+    if (jj_scan_token(QUOTED_STRING)) return true;
+    return false;
+  }
+
+  private boolean jj_3_66()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(53)) {
+    jj_scanpos = xsp;
+    if (jj_3R_63()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3_50()
+ {
+    if (jj_3R_42()) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(40)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(37)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(39)) return true;
+    }
+    }
+    return false;
+  }
+
   private boolean jj_3_16()
  {
     Token xsp;
@@ -6057,14 +6074,10 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_66()
+  private boolean jj_3_49()
  {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
-    jj_scanpos = xsp;
-    if (jj_3R_63()) return true;
-    }
+    if (jj_3R_43()) return true;
+    if (jj_scan_token(WHERE)) return true;
     return false;
   }
 
@@ -6079,18 +6092,21 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_50()
+  private boolean jj_3_65()
  {
-    if (jj_3R_42()) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(40)) {
+    if (jj_scan_token(53)) {
     jj_scanpos = xsp;
-    if (jj_scan_token(37)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(39)) return true;
+    if (jj_3R_62()) return true;
     }
-    }
+    return false;
+  }
+
+  private boolean jj_3_48()
+ {
+    if (jj_3R_42()) return true;
+    if (jj_scan_token(WHERE)) return true;
     return false;
   }
 
@@ -6114,37 +6130,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_49()
- {
-    if (jj_3R_43()) return true;
-    if (jj_scan_token(WHERE)) return true;
-    return false;
-  }
-
-  private boolean jj_3_65()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
-    jj_scanpos = xsp;
-    if (jj_3R_62()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3_48()
- {
-    if (jj_3R_42()) return true;
-    if (jj_scan_token(WHERE)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_112()
- {
-    if (jj_scan_token(QUOTED_STRING)) return true;
-    return false;
-  }
-
   private boolean jj_3_67()
  {
     if (jj_3R_42()) return true;
@@ -6154,6 +6139,12 @@ keys.add(key);
     jj_scanpos = xsp;
     if (jj_scan_token(39)) return true;
     }
+    return false;
+  }
+
+  private boolean jj_3R_112()
+ {
+    if (jj_scan_token(QUOTED_STRING)) return true;
     return false;
   }
 
@@ -6186,6 +6177,20 @@ keys.add(key);
     }
     }
     }
+    return false;
+  }
+
+  private boolean jj_3R_49()
+ {
+    if (jj_scan_token(NUMERIC)) return true;
+    if (jj_scan_token(COMMA)) return true;
+    return false;
+  }
+
+  private boolean jj_3_44()
+ {
+    if (jj_scan_token(NUMERIC)) return true;
+    if (jj_scan_token(COMMA)) return true;
     return false;
   }
 
@@ -6232,17 +6237,21 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_49()
+  private boolean jj_3R_61()
  {
     if (jj_scan_token(NUMERIC)) return true;
     if (jj_scan_token(COMMA)) return true;
     return false;
   }
 
-  private boolean jj_3_44()
+  private boolean jj_3_39()
  {
-    if (jj_scan_token(NUMERIC)) return true;
-    if (jj_scan_token(COMMA)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(53)) {
+    jj_scanpos = xsp;
+    if (jj_3R_49()) return true;
+    }
     return false;
   }
 
@@ -6272,33 +6281,9 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_61()
- {
-    if (jj_scan_token(NUMERIC)) return true;
-    if (jj_scan_token(COMMA)) return true;
-    return false;
-  }
-
-  private boolean jj_3_39()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
-    jj_scanpos = xsp;
-    if (jj_3R_49()) return true;
-    }
-    return false;
-  }
-
   private boolean jj_3R_36()
  {
     if (jj_scan_token(OPEN_BRACKET)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_103()
- {
-    if (jj_scan_token(NUMERIC)) return true;
     return false;
   }
 
@@ -6365,9 +6350,9 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_114()
+  private boolean jj_3R_103()
  {
-    if (jj_scan_token(QUOTED_STRING)) return true;
+    if (jj_scan_token(NUMERIC)) return true;
     return false;
   }
 
@@ -6425,29 +6410,9 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_12()
+  private boolean jj_3R_114()
  {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(90)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(91)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(88)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(92)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(97)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(93)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(96)) return true;
-    }
-    }
-    }
-    }
-    }
-    }
+    if (jj_scan_token(QUOTED_STRING)) return true;
     return false;
   }
 
@@ -6476,17 +6441,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_113()
- {
-    Token xsp;
-    if (jj_3_12()) return true;
-    while (true) {
-      xsp = jj_scanpos;
-      if (jj_3_12()) { jj_scanpos = xsp; break; }
-    }
-    return false;
-  }
-
   private boolean jj_3_37()
  {
     Token xsp;
@@ -6502,6 +6456,55 @@ keys.add(key);
  {
     if (jj_scan_token(ALPHANUMERIC)) return true;
     if (jj_scan_token(OPEN_PARENTHESES)) return true;
+    return false;
+  }
+
+  private boolean jj_3_12()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(90)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(91)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(88)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(92)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(97)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(93)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(96)) return true;
+    }
+    }
+    }
+    }
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_48()
+ {
+    if (jj_scan_token(NUMERIC)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_113()
+ {
+    Token xsp;
+    if (jj_3_12()) return true;
+    while (true) {
+      xsp = jj_scanpos;
+      if (jj_3_12()) { jj_scanpos = xsp; break; }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_47()
+ {
+    if (jj_3R_77()) return true;
     return false;
   }
 
@@ -6522,18 +6525,6 @@ keys.add(key);
   private boolean jj_3_13()
  {
     if (jj_3R_32()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_48()
- {
-    if (jj_scan_token(NUMERIC)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_47()
- {
-    if (jj_3R_77()) return true;
     return false;
   }
 
@@ -6618,6 +6609,19 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3_41()
+ {
+    if (jj_scan_token(OPEN_BRACKET)) return true;
+    if (jj_scan_token(NUMERIC)) return true;
+    return false;
+  }
+
+  private boolean jj_3_23()
+ {
+    if (jj_3R_30()) return true;
+    return false;
+  }
+
   private boolean jj_3_11()
  {
     if (jj_scan_token(OPEN_BRACKET)) return true;
@@ -6626,10 +6630,14 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_41()
+  private boolean jj_3_62()
  {
-    if (jj_scan_token(OPEN_BRACKET)) return true;
-    if (jj_scan_token(NUMERIC)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(53)) {
+    jj_scanpos = xsp;
+    if (jj_3R_60()) return true;
+    }
     return false;
   }
 
@@ -6641,6 +6649,13 @@ keys.add(key);
     jj_scanpos = xsp;
     if (jj_scan_token(96)) return true;
     }
+    return false;
+  }
+
+  private boolean jj_3R_59()
+ {
+    if (jj_3R_43()) return true;
+    if (jj_scan_token(COMMA)) return true;
     return false;
   }
 
@@ -6664,33 +6679,9 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_23()
- {
-    if (jj_3R_30()) return true;
-    return false;
-  }
-
   private boolean jj_3_10()
  {
     if (jj_3R_30()) return true;
-    return false;
-  }
-
-  private boolean jj_3_62()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
-    jj_scanpos = xsp;
-    if (jj_3R_60()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_59()
- {
-    if (jj_3R_43()) return true;
-    if (jj_scan_token(COMMA)) return true;
     return false;
   }
 
@@ -6707,6 +6698,17 @@ keys.add(key);
     }
     xsp = jj_scanpos;
     if (jj_3_11()) jj_scanpos = xsp;
+    return false;
+  }
+
+  private boolean jj_3_61()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(53)) {
+    jj_scanpos = xsp;
+    if (jj_3R_59()) return true;
+    }
     return false;
   }
 
@@ -6741,14 +6743,10 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_61()
+  private boolean jj_3R_58()
  {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
-    jj_scanpos = xsp;
-    if (jj_3R_59()) return true;
-    }
+    if (jj_scan_token(NUMERIC)) return true;
+    if (jj_scan_token(COMMA)) return true;
     return false;
   }
 
@@ -6763,7 +6761,18 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_58()
+  private boolean jj_3_60()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(53)) {
+    jj_scanpos = xsp;
+    if (jj_3R_58()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_45()
  {
     if (jj_scan_token(NUMERIC)) return true;
     if (jj_scan_token(COMMA)) return true;
@@ -6776,17 +6785,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_60()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
-    jj_scanpos = xsp;
-    if (jj_3R_58()) return true;
-    }
-    return false;
-  }
-
   private boolean jj_3_9()
  {
     if (jj_3R_28()) return true;
@@ -6794,20 +6792,7 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_45()
- {
-    if (jj_scan_token(NUMERIC)) return true;
-    if (jj_scan_token(COMMA)) return true;
-    return false;
-  }
-
   private boolean jj_3_7()
- {
-    if (jj_3R_27()) return true;
-    return false;
-  }
-
-  private boolean jj_3_4()
  {
     if (jj_3R_27()) return true;
     return false;
@@ -6824,13 +6809,7 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_3()
- {
-    if (jj_3R_27()) return true;
-    return false;
-  }
-
-  private boolean jj_3_5()
+  private boolean jj_3_4()
  {
     if (jj_3R_27()) return true;
     return false;
@@ -6846,6 +6825,18 @@ keys.add(key);
  {
     if (jj_scan_token(NUMERIC)) return true;
     if (jj_scan_token(COMMA)) return true;
+    return false;
+  }
+
+  private boolean jj_3_3()
+ {
+    if (jj_3R_27()) return true;
+    return false;
+  }
+
+  private boolean jj_3_5()
+ {
+    if (jj_3R_27()) return true;
     return false;
   }
 
@@ -6905,16 +6896,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_99()
- {
-    if (jj_3R_29()) return true;
-    if (jj_3R_94()) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3_7()) jj_scanpos = xsp;
-    return false;
-  }
-
   private boolean jj_3R_81()
  {
     if (jj_3R_90()) return true;
@@ -6949,41 +6930,21 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3R_99()
+ {
+    if (jj_3R_29()) return true;
+    if (jj_3R_94()) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3_7()) jj_scanpos = xsp;
+    return false;
+  }
+
   private boolean jj_3R_98()
  {
     if (jj_3R_108()) return true;
     if (jj_3R_109()) return true;
     if (jj_3R_109()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_97()
- {
-    if (jj_3R_106()) return true;
-    if (jj_3R_107()) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3_5()) jj_scanpos = xsp;
-    return false;
-  }
-
-  private boolean jj_3R_96()
- {
-    if (jj_3R_104()) return true;
-    if (jj_3R_105()) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3_4()) jj_scanpos = xsp;
-    return false;
-  }
-
-  private boolean jj_3R_95()
- {
-    if (jj_3R_102()) return true;
-    if (jj_3R_103()) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3_3()) jj_scanpos = xsp;
     return false;
   }
 
@@ -7013,24 +6974,13 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_93()
+  private boolean jj_3R_97()
  {
-    if (jj_3R_43()) return true;
+    if (jj_3R_106()) return true;
+    if (jj_3R_107()) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_95()) {
-    jj_scanpos = xsp;
-    if (jj_3R_96()) {
-    jj_scanpos = xsp;
-    if (jj_3R_97()) {
-    jj_scanpos = xsp;
-    if (jj_3R_98()) {
-    jj_scanpos = xsp;
-    if (jj_3R_99()) return true;
-    }
-    }
-    }
-    }
+    if (jj_3_5()) jj_scanpos = xsp;
     return false;
   }
 
@@ -7065,21 +7015,43 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_8()
+  private boolean jj_3R_96()
  {
-    if (jj_3R_28()) return true;
-    if (jj_3R_29()) return true;
-    if (jj_3R_94()) return true;
+    if (jj_3R_104()) return true;
+    if (jj_3R_105()) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3_4()) jj_scanpos = xsp;
     return false;
   }
 
-  private boolean jj_3R_92()
+  private boolean jj_3R_95()
  {
+    if (jj_3R_102()) return true;
+    if (jj_3R_103()) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3_8()) {
+    if (jj_3_3()) jj_scanpos = xsp;
+    return false;
+  }
+
+  private boolean jj_3R_93()
+ {
+    if (jj_3R_43()) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_95()) {
     jj_scanpos = xsp;
-    if (jj_3R_93()) return true;
+    if (jj_3R_96()) {
+    jj_scanpos = xsp;
+    if (jj_3R_97()) {
+    jj_scanpos = xsp;
+    if (jj_3R_98()) {
+    jj_scanpos = xsp;
+    if (jj_3R_99()) return true;
+    }
+    }
+    }
     }
     return false;
   }
@@ -7117,6 +7089,14 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3_8()
+ {
+    if (jj_3R_28()) return true;
+    if (jj_3R_29()) return true;
+    if (jj_3R_94()) return true;
+    return false;
+  }
+
   private boolean jj_3_22()
  {
     Token xsp;
@@ -7139,6 +7119,17 @@ keys.add(key);
     }
     }
     }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_92()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3_8()) {
+    jj_scanpos = xsp;
+    if (jj_3R_93()) return true;
     }
     return false;
   }
@@ -7174,12 +7165,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_79()
- {
-    if (jj_scan_token(CONJUNCTION)) return true;
-    return false;
-  }
-
   private boolean jj_3R_66()
  {
     if (jj_scan_token(NUMERIC)) return true;
@@ -7187,22 +7172,9 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_68()
- {
-    if (jj_scan_token(DISJUNCTION)) return true;
-    return false;
-  }
-
   private boolean jj_3_56()
  {
     if (jj_scan_token(NUMERIC)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_91()
- {
-    if (jj_scan_token(NAVIGATION_SCOPE_OPEN)) return true;
-    if (jj_3R_22()) return true;
     return false;
   }
 
@@ -7237,6 +7209,53 @@ keys.add(key);
     return false;
   }
 
+  private boolean jj_3R_79()
+ {
+    if (jj_scan_token(CONJUNCTION)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_68()
+ {
+    if (jj_scan_token(DISJUNCTION)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_84()
+ {
+    if (jj_scan_token(OPEN_BRACKET)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_91()
+ {
+    if (jj_scan_token(NAVIGATION_SCOPE_OPEN)) return true;
+    if (jj_3R_22()) return true;
+    return false;
+  }
+
+  private boolean jj_3_30()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(53)) {
+    jj_scanpos = xsp;
+    if (jj_3R_41()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_77()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_84()) {
+    jj_scanpos = xsp;
+    if (jj_3R_85()) return true;
+    }
+    return false;
+  }
+
   private boolean jj_3_20()
  {
     Token xsp;
@@ -7266,24 +7285,6 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_26()
- {
-    if (jj_3R_70()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_84()
- {
-    if (jj_scan_token(OPEN_BRACKET)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_88()
- {
-    if (jj_3R_92()) return true;
-    return false;
-  }
-
   private boolean jj_3R_31()
  {
     Token xsp;
@@ -7297,13 +7298,29 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_30()
+  private boolean jj_3R_26()
  {
+    if (jj_3R_70()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_88()
+ {
+    if (jj_3R_92()) return true;
+    return false;
+  }
+
+  private boolean jj_3_33()
+ {
+    if (jj_3R_43()) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
+    if (jj_scan_token(40)) {
     jj_scanpos = xsp;
-    if (jj_3R_41()) return true;
+    if (jj_scan_token(37)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(39)) return true;
+    }
     }
     return false;
   }
@@ -7361,29 +7378,21 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3R_77()
+  private boolean jj_3_29()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_84()) {
+    if (jj_scan_token(53)) {
     jj_scanpos = xsp;
-    if (jj_3R_85()) return true;
+    if (jj_3R_40()) return true;
     }
     return false;
   }
 
-  private boolean jj_3_33()
+  private boolean jj_3_54()
  {
-    if (jj_3R_43()) return true;
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(40)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(37)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(39)) return true;
-    }
-    }
+    if (jj_3R_55()) return true;
+    if (jj_scan_token(QUOTED_STRING)) return true;
     return false;
   }
 
@@ -7404,21 +7413,18 @@ keys.add(key);
     return false;
   }
 
-  private boolean jj_3_29()
+  private boolean jj_3_32()
  {
+    if (jj_3R_42()) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_scan_token(53)) {
+    if (jj_scan_token(40)) {
     jj_scanpos = xsp;
-    if (jj_3R_40()) return true;
+    if (jj_scan_token(37)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(39)) return true;
     }
-    return false;
-  }
-
-  private boolean jj_3_54()
- {
-    if (jj_3R_55()) return true;
-    if (jj_scan_token(QUOTED_STRING)) return true;
+    }
     return false;
   }
 

--- a/src/main/java/com/cinchapi/ccl/grammar/ModificationKeySymbol.java
+++ b/src/main/java/com/cinchapi/ccl/grammar/ModificationKeySymbol.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.ccl.grammar;
+
+import java.util.Objects;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * A {@link ModificationKeySymbol} pairs a {@link KeyTokenSymbol} with a
+ * timestamp that marks an addition-relative binding: the key binds to the
+ * values whose <em>add</em> occurred in the half-open interval
+ * {@code [timestamp, now)}, start-inclusive at the timestamp and
+ * end-exclusive at the present moment ({@code key[<timestamp>~]}).
+ *
+ * <p>This differs from a {@link TemporalKeySymbol}, which binds the single
+ * value <em>present at</em> the instant regardless of when it was added,
+ * and from a {@link TemporalRangeKeySymbol}, which binds the values
+ * <em>present during</em> an interval regardless of their add time. A
+ * value added before the timestamp is not in range here even if it is
+ * still present.
+ *
+ * <p>This symbol records the endpoint only; it does not decide what a
+ * read returns. That evaluation lives server-side and is out of scope for
+ * the grammar layer.
+ *
+ * <p>As with {@link TemporalKeySymbol}, a {@link NavigationKeySymbol} is
+ * never wrapped and an already-parameterized key is rejected, enforcing
+ * the "at most one bracket-timestamp parameter per key" invariant the
+ * rest of the AST relies on.
+ *
+ * @author Jeff Nelson
+ */
+public final class ModificationKeySymbol
+        extends KeyTokenSymbol<KeyTokenSymbol<?>> {
+
+    /**
+     * The inclusive start of the addition window; the end of the window is
+     * the (exclusive) present moment.
+     */
+    private final TimestampSymbol timestamp;
+
+    /**
+     * Construct a new {@link ModificationKeySymbol}.
+     *
+     * @param key the wrapped {@link KeyTokenSymbol}; must not be a
+     *            {@link NavigationKeySymbol} (navigation timestamps live
+     *            on the path's stops) and must not already be
+     *            parameterized (a key carries at most one
+     *            bracket-timestamp parameter)
+     * @param timestamp the inclusive start of the addition window
+     * @throws IllegalArgumentException if {@code key} is a
+     *             {@link NavigationKeySymbol} or already parameterized
+     */
+    public ModificationKeySymbol(KeyTokenSymbol<?> key,
+            TimestampSymbol timestamp) {
+        super(Preconditions.checkNotNull(key));
+        Preconditions.checkArgument(!(key instanceof NavigationKeySymbol),
+                "ModificationKeySymbol cannot wrap a NavigationKeySymbol; "
+                        + "modification bindings on navigation keys are not "
+                        + "yet supported");
+        Preconditions.checkArgument(!key.isParameterized(),
+                "ModificationKeySymbol cannot wrap an already-parameterized "
+                        + "key; a key carries at most one bracket-timestamp "
+                        + "parameter");
+        this.timestamp = Preconditions.checkNotNull(timestamp);
+    }
+
+    /**
+     * Return the inclusive start of the addition window.
+     *
+     * @return the timestamp {@link TimestampSymbol}
+     */
+    public TimestampSymbol timestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(this == obj) {
+            return true;
+        }
+        else if(!(obj instanceof ModificationKeySymbol)) {
+            return false;
+        }
+        ModificationKeySymbol other = (ModificationKeySymbol) obj;
+        return key.equals(other.key) && timestamp.equals(other.timestamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, timestamp);
+    }
+
+    @Override
+    public String toString() {
+        return key.toString() + "[" + timestamp.timestamp() + "~]";
+    }
+
+    @Override
+    public String baseKey() {
+        return key.baseKey();
+    }
+
+    @Override
+    public boolean isParameterized() {
+        return true;
+    }
+
+    @Override
+    public KeyTokenSymbol<?> stripParameters() {
+        return key.stripParameters();
+    }
+
+}

--- a/src/test/java/com/cinchapi/ccl/BracketTimestampCommandTest.java
+++ b/src/test/java/com/cinchapi/ccl/BracketTimestampCommandTest.java
@@ -28,6 +28,7 @@ import com.cinchapi.ccl.grammar.NavigationKeySymbol;
 import com.cinchapi.ccl.grammar.NavigationKeyStop;
 import com.cinchapi.ccl.grammar.OrderComponentSymbol;
 import com.cinchapi.ccl.grammar.OrderSymbol;
+import com.cinchapi.ccl.grammar.ModificationKeySymbol;
 import com.cinchapi.ccl.grammar.TemporalKeySymbol;
 import com.cinchapi.ccl.grammar.TemporalRangeKeySymbol;
 import com.cinchapi.ccl.grammar.command.BrowseSymbol;
@@ -215,6 +216,49 @@ public class BracketTimestampCommandTest {
     public void testAuditRejectsRangeKey() {
         assertCommandRejected(
                 String.format("audit name[%d...%d] in 1", T1, T2),
+                "audit command");
+    }
+
+    @Test
+    public void testSelectModificationKeyBracket() {
+        SelectSymbol cmd = parseCommand(
+                String.format("select locked[%d~] from 1", T1),
+                SelectSymbol.class);
+        assertModificationKey(cmd.keys().iterator().next(), "locked", T1);
+    }
+
+    @Test
+    public void testGetModificationKeyBracket() {
+        GetSymbol cmd = parseCommand(
+                String.format("get locked[%d~] from 1", T1),
+                GetSymbol.class);
+        assertModificationKey(cmd.keys().iterator().next(), "locked", T1);
+    }
+
+    @Test
+    public void testFindModificationKeyBracket() {
+        AbstractSyntaxTree tree = compiler().parse(
+                String.format("find locked[%d~] = \"pod-A\"", T1));
+        Assert.assertTrue(tree instanceof CommandTree);
+        com.cinchapi.ccl.syntax.ConditionTree cond =
+                ((CommandTree) tree).conditionTree();
+        com.cinchapi.ccl.grammar.ExpressionSymbol expr =
+                (com.cinchapi.ccl.grammar.ExpressionSymbol)
+                        ((com.cinchapi.ccl.syntax.ExpressionTree) cond).root();
+        assertModificationKey(expr.key(), "locked", T1);
+    }
+
+    @Test
+    public void testAddRejectsModificationKey() {
+        assertCommandRejected(
+                String.format("add locked[%d~] as \"pod-A\" in 1", T1),
+                "add command");
+    }
+
+    @Test
+    public void testAuditRejectsModificationKey() {
+        assertCommandRejected(
+                String.format("audit locked[%d~] in 1", T1),
                 "audit command");
     }
 
@@ -533,6 +577,19 @@ public class BracketTimestampCommandTest {
         Assert.assertEquals(expectedKey, ((KeySymbol) range.key()).key());
         Assert.assertEquals(expectedStart, range.start().timestamp());
         Assert.assertEquals(expectedEnd, range.end().timestamp());
+    }
+
+    private void assertModificationKey(KeyTokenSymbol<?> key,
+            String expectedKey, long expectedTs) {
+        Assert.assertTrue(
+                "expected ModificationKeySymbol but got "
+                        + key.getClass().getSimpleName(),
+                key instanceof ModificationKeySymbol);
+        ModificationKeySymbol modification = (ModificationKeySymbol) key;
+        Assert.assertTrue(modification.key() instanceof KeySymbol);
+        Assert.assertEquals(expectedKey,
+                ((KeySymbol) modification.key()).key());
+        Assert.assertEquals(expectedTs, modification.timestamp().timestamp());
     }
 
     private static final Function<String, Object> VALUE_FN = Convert::stringToJava;

--- a/src/test/java/com/cinchapi/ccl/BracketTimestampMatrixTest.java
+++ b/src/test/java/com/cinchapi/ccl/BracketTimestampMatrixTest.java
@@ -471,6 +471,56 @@ public class BracketTimestampMatrixTest {
     }
 
     /**
+     * <strong>Goal:</strong> Verify that a {@code ~} appearing
+     * <em>inside</em> a quoted timestamp ({@code foo["last week ~"] = X})
+     * is not mistaken for a trailing modification marker. The marker is
+     * recognized only when {@code ~} is the final, unquoted character of
+     * the bracket content; because the closing quote is the last
+     * character here, the content resolves as an ordinary single-instant
+     * timestamp and yields a {@link TemporalKeySymbol}, not a
+     * {@link ModificationKeySymbol}.
+     */
+    @Test
+    public void testM7_QuotedTildeIsNotMarker() {
+        KeyTokenSymbol<?> key = parseExpression("foo[\"last week ~\"] = \"X\"")
+                .key();
+        Assert.assertFalse(
+                "a '~' inside quotes must not be read as a modification "
+                        + "marker, but parsed to a ModificationKeySymbol",
+                key instanceof ModificationKeySymbol);
+        Assert.assertTrue(
+                "expected TemporalKeySymbol but was "
+                        + key.getClass().getSimpleName(),
+                key instanceof TemporalKeySymbol);
+        Assert.assertEquals("foo",
+                ((KeySymbol) ((TemporalKeySymbol) key).key()).key().toString());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that the {@code search_match} /
+     * {@code contains} keyword spellings of the {@code SEARCH_MATCH}
+     * token are rejected inside a key bracket. The token is admitted only
+     * to capture the standalone {@code ~} marker; a keyword spelling is
+     * meaningless here and must fail at parse time with a clear message
+     * rather than fall through to a confusing timestamp-parse error.
+     */
+    @Test
+    public void testM8_SearchKeywordInBracketRejected() {
+        String ccl = String.format("foo[%d contains] = \"X\"", T1);
+        try {
+            compiler().parse(ccl);
+            Assert.fail("expected SyntaxException for search keyword in "
+                    + "bracket in: " + ccl);
+        }
+        catch (SyntaxException e) {
+            Assert.assertTrue(
+                    "expected message to mention the '~' marker but was: "
+                            + e.getMessage(),
+                    e.getMessage().contains("'~' modification marker"));
+        }
+    }
+
+    /**
      * <strong>Goal:</strong> Verify that an unbracketed navigation key
      * ({@code a.foo = X}) parses to a {@link NavigationKeySymbol}
      * whose stops carry no timestamps.

--- a/src/test/java/com/cinchapi/ccl/BracketTimestampMatrixTest.java
+++ b/src/test/java/com/cinchapi/ccl/BracketTimestampMatrixTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import com.cinchapi.ccl.grammar.ExpressionSymbol;
 import com.cinchapi.ccl.grammar.KeySymbol;
 import com.cinchapi.ccl.grammar.KeyTokenSymbol;
+import com.cinchapi.ccl.grammar.ModificationKeySymbol;
 import com.cinchapi.ccl.grammar.NavigationKeyStop;
 import com.cinchapi.ccl.grammar.NavigationKeySymbol;
 import com.cinchapi.ccl.grammar.Symbol;
@@ -345,6 +346,128 @@ public class BracketTimestampMatrixTest {
     public void testRoundTripRangeResolvedEndpoints() {
         assertRoundTrip("score[\"2024-01-01\"...\"2024-02-01\"] = \"X\"");
         assertRoundTrip("foo[last week...] = \"X\"");
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that an addition-marker on a flat leaf
+     * ({@code foo[t1~] = X}) parses to a {@link ModificationKeySymbol}
+     * carrying the marked timestamp. The half-open {@code [t1, now)}
+     * add-window intent is documented here even though the parser only
+     * records the endpoint: a value added at or after {@code t1} is in
+     * range, a value added before {@code t1} (even if still present) is
+     * not.
+     */
+    @Test
+    public void testM1_AfterMarkerNumeric() {
+        String ccl = String.format("foo[%d~] = \"X\"", T1);
+        ModificationKeySymbol modification = assertLeafKeyModification(
+                parseExpression(ccl), "foo");
+        Assert.assertEquals(T1, modification.timestamp().timestamp());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that an addition-marker whose
+     * timestamp is a quoted natural-language phrase
+     * ({@code foo["last week"~] = X}) parses to a
+     * {@link ModificationKeySymbol}. This exercises the detached
+     * {@code ~} token path (the marker is lexed as a {@code SEARCH_MATCH}
+     * separate from the quoted timestamp), which the numeric case, where
+     * {@code ~} attaches to the digits, does not. Compared at day
+     * precision because the phrase is anchored to the current instant.
+     */
+    @Test
+    public void testM2_AfterMarkerQuotedNaturalLanguage() {
+        TimestampSymbol expected = new TimestampSymbol(
+                NaturalLanguage.parseMicros("last week"), TimeUnit.DAYS);
+        ModificationKeySymbol modification = assertLeafKeyModification(
+                parseExpression("foo[\"last week\"~] = \"X\""), "foo");
+        Assert.assertEquals(expected, modification.timestamp());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that the optional {@code at} keyword
+     * is accepted in front of the marked timestamp
+     * ({@code foo[at t1~] = X}) and yields the same
+     * {@link ModificationKeySymbol} as the keyword-less form.
+     */
+    @Test
+    public void testM3_AfterMarkerKeywordEquivalence() {
+        ModificationKeySymbol withKeyword = assertLeafKeyModification(
+                parseExpression(String.format("foo[at %d~] = \"X\"", T1)),
+                "foo");
+        Assert.assertEquals(T1, withKeyword.timestamp().timestamp());
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that the leading before-marker form
+     * ({@code foo[~t1] = X}) is rejected at parse time, since the
+     * added-before semantic is not yet supported.
+     */
+    @Test
+    public void testM4_BeforeMarkerRejected() {
+        String ccl = String.format("foo[~%d] = \"X\"", T1);
+        try {
+            compiler().parse(ccl);
+            Assert.fail("expected SyntaxException for before-marker in: "
+                    + ccl);
+        }
+        catch (SyntaxException e) {
+            Assert.assertTrue(
+                    "expected message to mention 'not yet supported' but "
+                            + "was: " + e.getMessage(),
+                    e.getMessage().contains("not yet supported"));
+        }
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that combining a range with an
+     * addition-marker ({@code foo[t1...t2~] = X}) is rejected, since a
+     * marker binds a single instant rather than a range.
+     */
+    @Test
+    public void testM5_RangeWithMarkerRejected() {
+        String ccl = String.format("foo[%d...%d~] = \"X\"", T1, T2);
+        try {
+            compiler().parse(ccl);
+            Assert.fail("expected SyntaxException for range-with-marker in: "
+                    + ccl);
+        }
+        catch (SyntaxException e) {
+            Assert.assertTrue(
+                    "expected message to mention 'single instant, not a "
+                            + "range' but was: " + e.getMessage(),
+                    e.getMessage().contains("single instant, not a range"));
+        }
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify that a marker bracket followed by a
+     * second bracket on one leaf ({@code foo[t1~][t2] = X}) is rejected,
+     * since {@code Key()} accepts at most one trailing bracket.
+     */
+    @Test
+    public void testM6_MarkerBeforeSingleBracketRejected() {
+        String ccl = String.format("foo[%d~][%d] = \"X\"", T1, T2);
+        try {
+            compiler().parse(ccl);
+            Assert.fail("expected SyntaxException for double bracket with "
+                    + "marker in: " + ccl);
+        }
+        catch (SyntaxException e) {
+            // Pass — Key()'s optional bracket cannot fire twice.
+        }
+    }
+
+    /**
+     * <strong>Goal:</strong> Verify lossless round-trip of the addition
+     * marker. The canonical {@code toString()} renders the timestamp as
+     * resolved microseconds with a trailing {@code ~}, so re-parsing the
+     * re-emitted form must yield an equal AST.
+     */
+    @Test
+    public void testRoundTripModification() {
+        assertRoundTrip(String.format("foo[%d~] = \"X\"", T1));
+        assertRoundTrip("foo[\"last week\"~] = \"X\"");
     }
 
     /**
@@ -1077,6 +1200,20 @@ public class BracketTimestampMatrixTest {
         TemporalRangeKeySymbol range = assertLeafKeyRange(expr, expectedKey);
         Assert.assertEquals(expectedStart, range.start().timestamp());
         Assert.assertEquals(expectedEnd, range.end().timestamp());
+    }
+
+    private ModificationKeySymbol assertLeafKeyModification(
+            ExpressionSymbol expr, String expectedKey) {
+        KeyTokenSymbol<?> key = expr.key();
+        Assert.assertTrue(
+                "expected ModificationKeySymbol but was "
+                        + key.getClass().getSimpleName(),
+                key instanceof ModificationKeySymbol);
+        ModificationKeySymbol modification = (ModificationKeySymbol) key;
+        Assert.assertTrue(modification.key() instanceof KeySymbol);
+        Assert.assertEquals(expectedKey,
+                ((KeySymbol) modification.key()).key().toString());
+        return modification;
     }
 
     private void assertLeafKeyUnstamped(AbstractSyntaxTree leaf) {

--- a/src/test/java/com/cinchapi/ccl/grammar/ModificationKeySymbolTest.java
+++ b/src/test/java/com/cinchapi/ccl/grammar/ModificationKeySymbolTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2013-2026 Cinchapi Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cinchapi.ccl.grammar;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ModificationKeySymbol}.
+ *
+ * @author Jeff Nelson
+ */
+public class ModificationKeySymbolTest {
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructRejectsNullKey() {
+        new ModificationKeySymbol(null, new TimestampSymbol(1L));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructRejectsNullTimestamp() {
+        new ModificationKeySymbol(new KeySymbol("foo"), null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructRejectsNavigationKeySymbolWrapping() {
+        new ModificationKeySymbol(new NavigationKeySymbol("a.b"),
+                new TimestampSymbol(1L));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructRejectsParameterizedKeyWrapping() {
+        TemporalKeySymbol inner = new TemporalKeySymbol(new KeySymbol("foo"),
+                new TimestampSymbol(1L));
+        new ModificationKeySymbol(inner, new TimestampSymbol(2L));
+    }
+
+    @Test
+    public void testTimestampAccessor() {
+        TimestampSymbol ts = new TimestampSymbol(1L);
+        ModificationKeySymbol symbol = new ModificationKeySymbol(
+                new KeySymbol("foo"), ts);
+        Assert.assertSame(ts, symbol.timestamp());
+    }
+
+    @Test
+    public void testToString() {
+        ModificationKeySymbol symbol = new ModificationKeySymbol(
+                new KeySymbol("foo"), new TimestampSymbol(123L));
+        Assert.assertEquals("foo[123~]", symbol.toString());
+    }
+
+    @Test
+    public void testEqualsWhenKeyAndTimestampMatch() {
+        ModificationKeySymbol a = new ModificationKeySymbol(
+                new KeySymbol("foo"), new TimestampSymbol(1L));
+        ModificationKeySymbol b = new ModificationKeySymbol(
+                new KeySymbol("foo"), new TimestampSymbol(1L));
+        Assert.assertEquals(a, b);
+        Assert.assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testNotEqualsWhenTimestampDiffers() {
+        ModificationKeySymbol a = new ModificationKeySymbol(
+                new KeySymbol("foo"), new TimestampSymbol(1L));
+        ModificationKeySymbol b = new ModificationKeySymbol(
+                new KeySymbol("foo"), new TimestampSymbol(2L));
+        Assert.assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testNotEqualsWhenKeyDiffers() {
+        ModificationKeySymbol a = new ModificationKeySymbol(
+                new KeySymbol("foo"), new TimestampSymbol(1L));
+        ModificationKeySymbol b = new ModificationKeySymbol(
+                new KeySymbol("bar"), new TimestampSymbol(1L));
+        Assert.assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testNotEqualsToTemporalKeySymbol() {
+        ModificationKeySymbol modification = new ModificationKeySymbol(
+                new KeySymbol("foo"), new TimestampSymbol(1L));
+        Assert.assertNotEquals(modification,
+                new TemporalKeySymbol(new KeySymbol("foo"),
+                        new TimestampSymbol(1L)));
+    }
+
+    @Test
+    public void testNotEqualsToTemporalRangeKeySymbol() {
+        ModificationKeySymbol modification = new ModificationKeySymbol(
+                new KeySymbol("foo"), new TimestampSymbol(1L));
+        Assert.assertNotEquals(modification,
+                new TemporalRangeKeySymbol(new KeySymbol("foo"),
+                        new TimestampSymbol(1L), null));
+    }
+
+    @Test
+    public void testBaseKeyDelegatesToWrappedKey() {
+        ModificationKeySymbol symbol = new ModificationKeySymbol(
+                new KeySymbol("foo"), new TimestampSymbol(1L));
+        Assert.assertEquals("foo", symbol.baseKey());
+    }
+
+    @Test
+    public void testIsParameterized() {
+        ModificationKeySymbol symbol = new ModificationKeySymbol(
+                new KeySymbol("foo"), new TimestampSymbol(1L));
+        Assert.assertTrue(symbol.isParameterized());
+    }
+
+    @Test
+    public void testStripParametersReturnsWrappedKey() {
+        KeySymbol inner = new KeySymbol("foo");
+        ModificationKeySymbol symbol = new ModificationKeySymbol(inner,
+                new TimestampSymbol(1L));
+        Assert.assertEquals(inner, symbol.stripParameters());
+    }
+
+}


### PR DESCRIPTION
Closes #75.

> **Stacked on #77 (GH-74).** This PR is based on `feature/GH-74`, so its diff shows only the GH-75 commits. **Merge #77 first;** GitHub then auto-retargets this PR's base to `develop`. The two are functionally independent — they just edit the same bracket-parsing chokepoint.

## What

Adds an **addition-relative** key-bracket binding on flat leaf keys: `foo[t1~]` binds the key to the values whose **add** occurred in the half-open window `[t1, now)` — start-inclusive at `t1`, end-exclusive at the present moment.

```
locked[1718380800000000~] = null      -- lock values ADDED at or after t
find locked[1700000000~] = "pod-A"    -- ...added at or after t, equal to pod-A
```

This is **grammar / AST / parse only**. Server-side evaluation is a separate concourse change (cinchapi/concourse#790).

### Distinct from the existing forms
| Form | Binds |
|------|-------|
| `foo[t]` | the value **present at** the instant `t`, regardless of add time |
| `foo[t1...t2]` (#74) | values **present during** `[t1, t2)`, regardless of add time |
| `foo[t1~]` (this PR) | values whose **add event** falls in `[t1, now)` |

A value added before `t1` is excluded by `foo[t1~]` even if it is still present — that's what powers the motivating stale-lock case: a record whose only lock value was added before the cutoff binds to nothing under `locked[<cutoff>~]` and is therefore claimable.

## How
- **Grammar:** accept a standalone `~` (`SEARCH_MATCH`) as a word token **inside `KeyBracketParameter` only**, so a detached marker after a quoted/NL timestamp is captured. `~`'s meaning outside brackets is unchanged.
- **`Parsing.applyKeyBracket`** (the chokepoint #74 introduced): trailing `~` → `ModificationKeySymbol`; leading `~t` (added-before) → rejected as not-yet-supported; a range combined with a marker (`t1...t2~`) → rejected.
- **`ModificationKeySymbol`** (new, sibling to `TemporalKeySymbol`): rejects navigation and already-parameterized keys; `isParameterized() == true`, so writes and `audit`/`chronicle`/`diff` reject it for free via the existing `requireNotParameterized` gate. Canonical `toString()` → `key[<micros>~]` (the `Keys.parse` cross-repo contract).

### Validation
- `foo[~t]` (added-before) → rejected. It's semantically equivalent to an existence-before range; deferred to that sibling work per the ticket.
- `foo[t1...t2~]` (range + marker) → rejected (a marker binds a single instant).
- `foo[t1~][t2]` (double bracket) → rejected.

## Tests
- **`ModificationKeySymbolTest`** (new): constructor guards, accessor, `equals`/`hashCode`, inequality vs `TemporalKeySymbol` **and** `TemporalRangeKeySymbol` with the same key+ts, `toString()`, parameter hooks.
- **`BracketTimestampMatrixTest`** (`M`-series): numeric marker, quoted/NL marker (exercises the detached-`~` path), keyword equivalence, and the before-marker / range-with-marker / double-bracket rejections, plus round-trip.
- **`BracketTimestampCommandTest`**: accepted on `select`/`get`/`find`; rejected on `add` and `audit`.

All pass locally (incl. `GrammarTest`/`JavaCCParserTest`/`CompilerJavaCCTest` regression), parser regenerates cleanly with no new warnings.

## Scope / follow-ups
- **Out of scope:** markers on navigation stops (`a[t1~].b`) and scope prefixes — leaf-only first cut, matching #74's boundary. Server-side evaluation.
- **Cross-repo:** ship in a ccl release; concourse then bumps its ccl pin before the evaluation change (cinchapi/concourse#790), whose `Keys.parse` must re-parse the canonical `key[<micros>~]` form.

Part of the connector data-sync locking initiative (cinchapi-server). Sibling grammar work: #74.
